### PR TITLE
Specified Module Target for Linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module:
+          - gophergate-wg-agent
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.

Fix issue where linting CI runs on root directory and throwing error since there are multiple go application that live in their own folder

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- NIL

## Changes Made

- Added module matrix into `lint.yaml` to make sure it targets specific module for linting

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.

This PR should be ready to merge once the linting action runs successfully.