### PR TITLE
Fix Looping Release Issue

### DIFF
--- a/.github/workflows/_release-one.yaml
+++ b/.github/workflows/_release-one.yaml
@@ -30,6 +30,12 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
+      - name: Skip if release PR
+        if: startsWith(github.head_ref, 'release/')
+        run: |
+          echo "Skipping because this is a release PR"
+          exit 0
+
       - name: Last tag for module
         id: last
         run: |


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.

There is an issue with looping release because the release ci is creating release as long as a PR is merged into dev. So to stop this we skip all release creation is PR that is merged is from `release/` branch.

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- NIL

## Changes Made

- Created a block to skip action is merging branch starts with `release/`.

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.

This can only be tested after merge. Logically it should be right so lets just approve and merge then test. If there are any issues lets move on from there.
