### PR TITLE
Logger Memory Flush & Dotenv Support

### DIFF
--- a/gophergate-core/go.mod
+++ b/gophergate-core/go.mod
@@ -7,4 +7,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
-require go.uber.org/multierr v1.10.0 // indirect
+require (
+	github.com/joho/godotenv v1.5.1 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+)

--- a/gophergate-core/go.sum
+++ b/gophergate-core/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=

--- a/gophergate-core/logx/logx.go
+++ b/gophergate-core/logx/logx.go
@@ -1,10 +1,14 @@
 package logx
 
 import (
+	"errors"
 	"os"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/Cyrof/GopherGate/gophergate-core/paths"
+	"github.com/joho/godotenv"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -41,7 +45,12 @@ func Default(app string) Config {
 	}
 }
 
-func Init(cfg Config) *zap.SugaredLogger {
+func Init(cfg Config) (*zap.SugaredLogger, func()) {
+	// try to access .env file (dev only)
+	if err := godotenv.Load(); err != nil {
+		_, _ = os.Stdout.WriteString("no .env file found, falling back to system environment variables" + "\n")
+	}
+
 	// decide mode
 	mode := cfg.Mode
 	if mode == Auto {
@@ -70,7 +79,6 @@ func Init(cfg Config) *zap.SugaredLogger {
 		dev.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		dev.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339)
 		core = zapcore.NewCore(zapcore.NewConsoleEncoder(dev), zapcore.AddSync(os.Stdout), cfg.Level)
-
 	case File:
 		d := paths.ForApp(cfg.App)
 		if err := d.Ensure(); err != nil {
@@ -89,5 +97,28 @@ func Init(cfg Config) *zap.SugaredLogger {
 	}
 
 	z := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
-	return z.Sugar()
+
+	flush := func() {
+		if err := z.Sync(); err != nil && !ignorableSyncErr(err) {
+			_, _ = os.Stderr.WriteString("logger sync error: " + err.Error() + "\n")
+		}
+	}
+	return z.Sugar(), flush
+}
+
+func ignorableSyncErr(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	// There is a common error where "invalid argument" is return when syncing stdout/stderr
+	if runtime.GOOS == "windows" && strings.Contains(strings.ToLower(err.Error()), "invalid argument") {
+		return true
+	}
+	// some writer may wrap EOF/closed pipe
+	if errors.Is(err, os.ErrClosed) {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.

There wasn't a way to flush the logger memory in each module. Therefore a memory flush function is created and return. This allows for defer memory flush for each module that uses the logger so to allow multi instance of the logger. Also added support for dotenv to allow for dev mode.

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- NIL

## Changes Made

- Create flush function that is returned
- Created support for dotenv

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
- Cant test the code changes here so lets merge this and test in `gophergate-wg-agent`.
