### PR TITLE
Reconfigure Wireguard Docker Compose

### DIFF
--- a/wireguard-dev/README.md
+++ b/wireguard-dev/README.md
@@ -3,15 +3,31 @@
 This folder contains a **Docker Compose setup** for running a WireGuard container using [linuxserver/wireguard](https://docs.linuxserver.io/images/docker-wireguard) image.
 It is intended for **development and simulation only**. The container acts as a backend WireGuard service so that [`gophergate-wg-agent`](../gophergate-wg-agent) can interact with it without needing WireGuard installed on the host.
 
+> **What Changed (Dev QoL)**: We now run the container with **host networking** so the `wg0` interface exists in the host network namespace. This lets a host-running agent use `wgctrl-go` directly. The required `sysctl` is set on the **host** (not inside the container).
+
 ## Prerequisites
 
 - Docker v28.4.0 and up
+- Linux host with `/dev/net/tun` available
+- WireGuard kernel module available (`wireguard`)
 
 Check that Docker is working:
 
 ```bash
 docker --version
 docker compose version
+ls -l /dev/net/tun
+sudo modprobe wireguard || true # ok if built-in; no output is fine
+```
+
+## One-time host sysctl (required)
+When using host networking, set this on the **host**:
+```bash
+# set now
+sudo sysctl -w net.ipv4.conf.all.src_valid_mark=1
+# make persistent
+echo 'net.ipv4.conf.all.src_valid_mark=1' | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
 ```
 
 ## Usage
@@ -30,6 +46,7 @@ This will:
 - Create the container `wireguard-dev`.
 - Generate a server config (`wg0.conf`) and a default peer (`devpeer`).
 - Mount all generated configs into `./wireguard/config`.
+- Bring up `wg0` **on the host** (via host networking).
 
 ### 2. View logs
 
@@ -39,17 +56,32 @@ docker logs wireguard-dev
 
 You should see startup information and confirmation that the WireGuard server is active.
 
-### 3. Access generated configs
+### 3. Verify WireGuard status (via container &mdash; no host install)
+```bash
+# show device, peers, handshakes, tx/rx, etc.
+docker exec -it wireguard-dev wg show 
+
+# show the server config currently applied
+docker exec -it wireguard-dev wg showconf wg0
+```
+(Optionally on the host)
+```bash
+ip -d link show wg0 # wg0 should exist since we use host networking
+```
+
+### 4. Access generated configs
 
 Peer configs are stored under:
 
 ```text
+# Peer config
 ./wireguard/config/peer_devpeer/peer_devpeer.conf
+
+# Server config
+./wireguard/config/wg_confs/wg0.conf
 ```
 
-The server config (`wg0.conf`) is under `./wireguard/config/wg_confs/`.
-
-### 4. Stop the container
+### 5. Stop the container
 
 To stop and remove the container + network:
 
@@ -72,25 +104,33 @@ The compose file includes the following environment variables:
 **Volumes:**
 
 - `./wireguard/config:/config` → stores keys, configs, and peer files persistently
+- `/dev/net/tun:/dev/net/tun` → allows WireGuard to create/manage the tunnel device.
+
 
 **Ports:**
-
-- `51820:51820/udp` → forwards host UDP port 51820 to the container (so you can connect locally with WireGuard client).
+- **Host networking**: _No port mapping needed_. WireGuard listens on `UDP/51820` on the host automatically.
+- **If you disable host networking (not recommended for this dev flow)**: expose the port explicitly:
+    - `51820:51820/udp` → forwards host UDP 51820 to the container. 
 
 **Capabilities:**
 
 - `NET_ADMIN` → required so the container can configure network interfaces.
-- `SYS_MODULE` → _optional_ but it allows the container to load kernel modules if needed.
+- `SYS_MODULE` → _optional_ but it allows the container to load kernel modules if needed (often not required if the module is already present on the host).
 
 **Sysctls:**
 
 - `net.ipv4.conf.all.src_valid_mark=1` is required for proper packet marking with WireGuard.
+- With **host networking**, Docker cannot set this inside the container. Set it on the **host** instead
 
-## Notes
+## How this ties to the agent 
+- In **dev**, the agent runs locally (host terminal) and manages `wg0` directly with `wgctrl-go`.
+- There is **no TCP "endpoint"** for the agent; it talks to the kernal via netlink.
+- For **Prod (k3s)** later, run the agent as a DaemonSet with `hostNetwork: true` (and typically `CAP_NET_ADMIN`) on the node that has WireGuard.
 
-- This setup is **local-only**. Do not expose it publicly.
-- Use it to test communication between `gophergate-wg-agent` and the WireGuard backend.
-- If you want to test a real VPN tunnel, import the generated `peer_devpeer.conf` into a WireGuard client (Windows, iOS, Android) and connect to `127.0.0.1:51820`.
+## Troubleshooting
+- `wg show` via `docker exec` **fails**: Ensure the container is running: `docker ps`, check logs: `docker logs wireguard-dev`.
+- **No** `wg0` **on host**: Confirm `/dev/net/tun` is presen and mounted, `sudo modprobe wireguard`, and that the host sysctl was applied (`sysctl net.ipv4.conf.all.src_valid_mark`).
+- **Can't connect a local WG client**: Ensure UDP/51820 is free and your firewall allows it. Import `peer_devpeer.conf` into a client and connect to `127.0.0.1:51820`.
 
 ## References
 

--- a/wireguard-dev/wireguard-env.yaml
+++ b/wireguard-dev/wireguard-env.yaml
@@ -18,6 +18,4 @@ services:
     volumes:
       - ./wireguard/config:/config
       - /dev/net/tun:/dev/net/run
-    sysctls:
-      - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped

--- a/wireguard-dev/wireguard-env.yaml
+++ b/wireguard-dev/wireguard-env.yaml
@@ -2,6 +2,7 @@ services:
   wireguard-dev:
     image: lscr.io/linuxserver/wireguard:latest
     container_name: wireguard-dev
+    network_mode: "host"
     cap_add:
       - NET_ADMIN
       - SYS_MODULE
@@ -9,9 +10,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Asia/Singapore
-      - SERVERURL=127.0.0.1     # local-only
+      - SERVERURL=127.0.0.1     
       - SERVERPORT=51820
-      - PEERS=devpeer           # force server mode; generates configs
+      - PEERS=devpeer           
       - PEERDNS=auto
       - LOG_CONFS=true
     volumes:

--- a/wireguard-dev/wireguard-env.yaml
+++ b/wireguard-dev/wireguard-env.yaml
@@ -17,8 +17,6 @@ services:
       - LOG_CONFS=true
     volumes:
       - ./wireguard/config:/config
-    ports:
-      - 51820:51820/udp
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped

--- a/wireguard-dev/wireguard-env.yaml
+++ b/wireguard-dev/wireguard-env.yaml
@@ -17,6 +17,7 @@ services:
       - LOG_CONFS=true
     volumes:
       - ./wireguard/config:/config
+      - /dev/net/tun:/dev/net/run
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.

Had to reconfigure the wireguard docker compose yaml to make sure the container runs in the same host network and also created a shared volume for the socket. This is allow the agent to talk to the wireguard service itself.

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- NIL

## Changes Made

- Made WireGuard docker container use the same host network

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
- Should not need to test since nothing major has changed.