### PR TITLE
refactor: Set docker image to only have module version and also module

### DIFF
--- a/.github/workflows/docker-on-release-merge.yaml
+++ b/.github/workflows/docker-on-release-merge.yaml
@@ -125,9 +125,7 @@ jobs:
                       cyrof/gophergate
                   tags: |
                       type=raw,value=${{ steps.parse.outputs.module_path }}-v${{ steps.parse.outputs.version}}
-                      type=raw,value=${{ steps.parse.outputs.module_path }}-${{ steps.parse.outputs.version }}
                       type=raw,value=${{ steps.parse.outputs.module_path }}-latest
-                      type=raw,value=latest
 
             - name: Build & push (multi-arch)
               if: ${{ steps.decide.outputs.publish == 'true' }}


### PR DESCRIPTION
latest tags

## Description

Describe the purpose of this pull request and the changes made.
Updates the Docker CI tagging strategy to reduce the number of published images and simplify version management.

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- NIL 

## Changes Made

- Removed global `latest` Docker tag.
- Removed non-versioned tags.
- Kept only:
   - `<module>-<version>`
   - `<module>:latest`

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
- Reduces image sprawl in Docker Hub.
- Makes images tagging clearer and easier to maintain.
- No runtime or application changes.