### PR TITLE
Add DB Persistence to grpc

### DIFF
--- a/gophergate-wg-agent/internal/grpcserver/server.go
+++ b/gophergate-wg-agent/internal/grpcserver/server.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/grpc"
 
 	gatewayv1 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v1"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func envOrDefault(key, def string) string {
@@ -17,7 +19,7 @@ func envOrDefault(key, def string) string {
 	return def
 }
 
-func Start(logger *zap.SugaredLogger) error {
+func Start(logger *zap.SugaredLogger, pool *pgxpool.Pool) error {
 	listenAddr := envOrDefault("GRPC_ADDR", ":7443")
 
 	list, err := net.Listen("tcp", listenAddr)
@@ -28,7 +30,14 @@ func Start(logger *zap.SugaredLogger) error {
 
 	srv := grpc.NewServer()
 
-	gatewayv1.RegisterWireGuardServiceServer(srv, NewWireGuardService())
+	var repo *data.Repository
+	if pool != nil {
+		repo = data.NewRepository(pool)
+	} else {
+		logger.Warn("grpc started without db: create via grpc will not persist")
+	}
+
+	gatewayv1.RegisterWireGuardServiceServer(srv, NewWireGuardService(repo))
 
 	logger.Infow("grpc server started", "addr", listenAddr)
 	return srv.Serve(list)

--- a/gophergate-wg-agent/internal/grpcserver/wireguard.go
+++ b/gophergate-wg-agent/internal/grpcserver/wireguard.go
@@ -176,6 +176,7 @@ func (s *WireGuardService) UpdatePeer(
 		AppendAllowedCIDRs: req.GetAppendAllowedCidrs(),
 		Endpoint:           req.GetEndpoint(),
 		KeepaliveSeconds:   keepalivePtr,
+		Repo:               s.repo,
 	}
 
 	svcResp, err := wgsvc.UpdatePeer(ctx, svcReq)

--- a/gophergate-wg-agent/internal/grpcserver/wireguard.go
+++ b/gophergate-wg-agent/internal/grpcserver/wireguard.go
@@ -8,15 +8,17 @@ import (
 	"google.golang.org/grpc/status"
 
 	gatewayv1 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v1"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/wgsvc"
 )
 
 type WireGuardService struct {
 	gatewayv1.UnimplementedWireGuardServiceServer
+	repo *data.Repository
 }
 
-func NewWireGuardService() *WireGuardService {
-	return &WireGuardService{}
+func NewWireGuardService(repo *data.Repository) *WireGuardService {
+	return &WireGuardService{repo: repo}
 }
 
 // CreatePeer handler for gRPC
@@ -34,6 +36,7 @@ func (s *WireGuardService) CreatePeer(
 		Endpoint:          req.GetEndpoint(),
 		KeepaliveSeconds:  int(req.GetKeepaliveSeconds()),
 		ReplaceAllowedIPs: req.GetReplaceAllowedIps(),
+		Repo:              s.repo,
 	}
 
 	svcResp, err := wgsvc.CreatePeer(ctx, svcReq)

--- a/gophergate-wg-agent/internal/grpcserver/wireguard.go
+++ b/gophergate-wg-agent/internal/grpcserver/wireguard.go
@@ -68,6 +68,7 @@ func (s *WireGuardService) DeletePeer(
 	svcReq := wgsvc.DeletePeerRequest{
 		Iface:     req.GetIface(),
 		PublicKey: req.GetPublicKey(),
+		Repo:      s.repo,
 	}
 
 	svcResp, err := wgsvc.DeletePeer(ctx, svcReq)

--- a/gophergate-wg-agent/internal/wgsvc/create.go
+++ b/gophergate-wg-agent/internal/wgsvc/create.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -75,10 +76,38 @@ func CreatePeer(ctx context.Context, req CreatePeerRequest) (CreatePeerResponse,
 		return CreatePeerResponse{}, fmt.Errorf("configure device: %w", err)
 	}
 
+	// persist to db
+	var id string
+	if req.Repo != nil {
+		primaryIP := pickPrimaryIP(req.AllowedCIDRs)
+
+		var err error
+		id, err = req.Repo.Insert(ctx, data.Peer{
+			Name:                req.Name,
+			PublicKey:           pub.String(),
+			IPAddress:           primaryIP,
+			Endpoint:            optionalString(req.Endpoint),
+			PersistentKeepalive: optionalI16(req.KeepaliveSeconds),
+		})
+		if err != nil {
+			// roll back to avoid drift
+			rollbackErr := cli.ConfigureDevice(req.Iface, wgtypes.Config{
+				Peers: []wgtypes.PeerConfig{
+					{PublicKey: pub, Remove: true},
+				},
+			})
+			if rollbackErr != nil {
+				fmt.Printf("rollback failed for peer %s on %s: %v\n", pub.String(), req.Iface, rollbackErr)
+			}
+			return CreatePeerResponse{}, fmt.Errorf("insert peer: %w", err)
+		}
+	}
+
 	return CreatePeerResponse{
 		Iface:         req.Iface,
 		Name:          req.Name,
 		PublicKey:     pub.String(),
 		ConfigApplied: true,
+		ID:            id,
 	}, nil
 }

--- a/gophergate-wg-agent/internal/wgsvc/delete.go
+++ b/gophergate-wg-agent/internal/wgsvc/delete.go
@@ -2,8 +2,10 @@ package wgsvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -35,6 +37,20 @@ func DeletePeer(ctx context.Context, req DeletePeerRequest) (DeletePeerResponse,
 
 	if err := cli.ConfigureDevice(req.Iface, cfg); err != nil {
 		return DeletePeerResponse{}, fmt.Errorf("configure device: %w", err)
+	}
+
+	if req.Repo != nil {
+		_, dbErr := req.Repo.DeleteByPublicKey(ctx, pub.String())
+		if dbErr != nil {
+			if errors.Is(dbErr, pgx.ErrNoRows) {
+				return DeletePeerResponse{
+					Iface:     req.Iface,
+					PublicKey: pub.String(),
+					Removed:   true,
+				}, nil
+			}
+			return DeletePeerResponse{}, fmt.Errorf("peer removed from interface but failed to delete from DB: %w", dbErr)
+		}
 	}
 
 	return DeletePeerResponse{

--- a/gophergate-wg-agent/internal/wgsvc/model.go
+++ b/gophergate-wg-agent/internal/wgsvc/model.go
@@ -62,6 +62,7 @@ type UpdatePeerResponse struct {
 type DeletePeerRequest struct {
 	Iface     string
 	PublicKey string
+	Repo      *data.Repository
 }
 
 type DeletePeerResponse struct {
@@ -69,4 +70,3 @@ type DeletePeerResponse struct {
 	PublicKey string `json:"public_key"`
 	Removed   bool   `json:"removed"`
 }
-

--- a/gophergate-wg-agent/internal/wgsvc/model.go
+++ b/gophergate-wg-agent/internal/wgsvc/model.go
@@ -1,5 +1,7 @@
 package wgsvc
 
+import "github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+
 type DeviceStatus struct {
 	Interface    string       `json:"interface"`
 	ListenPort   int          `json:"list_port"`
@@ -26,6 +28,7 @@ type CreatePeerRequest struct {
 	Endpoint          string
 	KeepaliveSeconds  int
 	ReplaceAllowedIPs bool
+	Repo              *data.Repository
 }
 
 type CreatePeerResponse struct {
@@ -33,6 +36,7 @@ type CreatePeerResponse struct {
 	Name          string `json:"name,omitempty"`
 	PublicKey     string `json:"public_key"`
 	ConfigApplied bool   `json:"config_applied"`
+	ID            string
 }
 
 type UpdatePeerRequest struct {
@@ -55,13 +59,14 @@ type UpdatePeerResponse struct {
 	} `json:"changed"`
 }
 
-type DeletePeerRequest struct { 
-	Iface string
+type DeletePeerRequest struct {
+	Iface     string
 	PublicKey string
 }
 
 type DeletePeerResponse struct {
-	Iface string `json:"iface"`
+	Iface     string `json:"iface"`
 	PublicKey string `json:"public_key"`
-	Removed bool `json:"removed"`
+	Removed   bool   `json:"removed"`
 }
+

--- a/gophergate-wg-agent/internal/wgsvc/model.go
+++ b/gophergate-wg-agent/internal/wgsvc/model.go
@@ -46,6 +46,7 @@ type UpdatePeerRequest struct {
 	AppendAllowedCIDRs []string
 	Endpoint           string
 	KeepaliveSeconds   *int
+	Repo               *data.Repository
 }
 
 type UpdatePeerResponse struct {

--- a/gophergate-wg-agent/internal/wgsvc/update.go
+++ b/gophergate-wg-agent/internal/wgsvc/update.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -36,8 +37,10 @@ func UpdatePeer(ctx context.Context, req UpdatePeerRequest) (UpdatePeerResponse,
 	var (
 		allowed        []net.IPNet
 		replaceAllowed bool
+		setAllowed     bool
 	)
 	if len(req.SetAllowedCIDRs) > 0 || len(req.AppendAllowedCIDRs) > 0 {
+		setAllowed = true
 		var list []string
 		if len(req.SetAllowedCIDRs) > 0 {
 			list = req.SetAllowedCIDRs
@@ -57,8 +60,8 @@ func UpdatePeer(ctx context.Context, req UpdatePeerRequest) (UpdatePeerResponse,
 
 	var ep *net.UDPAddr
 	setEndpoint := false
-	if req.Endpoint != "" {
-		addr, err := net.ResolveUDPAddr("udp", req.Endpoint)
+	if strings.TrimSpace(req.Endpoint) != "" {
+		addr, err := net.ResolveUDPAddr("udp", strings.TrimSpace(req.Endpoint))
 		if err != nil {
 			return UpdatePeerResponse{}, fmt.Errorf("invalid endpoint %q: %w", req.Endpoint, err)
 		}
@@ -77,7 +80,7 @@ func UpdatePeer(ctx context.Context, req UpdatePeerRequest) (UpdatePeerResponse,
 	pc := wgtypes.PeerConfig{
 		PublicKey: pub,
 	}
-	if len(allowed) > 0 || replaceAllowed {
+	if setAllowed {
 		pc.ReplaceAllowedIPs = replaceAllowed
 		pc.AllowedIPs = allowed
 	}
@@ -91,6 +94,31 @@ func UpdatePeer(ctx context.Context, req UpdatePeerRequest) (UpdatePeerResponse,
 	cfg := wgtypes.Config{Peers: []wgtypes.PeerConfig{pc}}
 	if err := cli.ConfigureDevice(req.Iface, cfg); err != nil {
 		return UpdatePeerResponse{}, fmt.Errorf("configure device: %w", err)
+	}
+
+	if req.Repo != nil {
+		var endpointPtr *string
+		if setEndpoint {
+			epStr := strings.TrimSpace(req.Endpoint)
+			endpointPtr = &epStr
+		}
+
+		dbIn := data.UpdatePeerDBInput{
+			ReplaceAllowed: req.SetAllowedCIDRs,
+			AppendAllowed:  req.AppendAllowedCIDRs,
+			SetEndpoint:    setEndpoint,
+			Endpoint:       endpointPtr,
+			SetKeepalive:   setKA,
+		}
+
+		if setKA {
+			ka16 := int16(*req.KeepaliveSeconds)
+			dbIn.Keepalive = &ka16
+		}
+
+		if _, err := req.Repo.UpdateByPublicKey(ctx, pub.String(), dbIn); err != nil {
+			return UpdatePeerResponse{}, fmt.Errorf("peer updated on interface but failed to sync DB: %w", err)
+		}
 	}
 
 	var resp UpdatePeerResponse

--- a/gophergate-wg-agent/internal/wgsvc/utils.go
+++ b/gophergate-wg-agent/internal/wgsvc/utils.go
@@ -1,0 +1,32 @@
+package wgsvc
+
+import "net"
+
+func pickPrimaryIP(cidrs []string) net.IP {
+	for _, c := range cidrs {
+		ip, ipNet, err := net.ParseCIDR(c)
+		if err != nil {
+			continue
+		}
+		ones, bits := ipNet.Mask.Size()
+		if (ip.To4() != nil && ones == 32 && bits == 32) || (ip.To4() == nil && ones == 128 && bits == 128) {
+			return ip
+		}
+	}
+	return nil
+}
+
+func optionalString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func optionalI16(v int) *int16 {
+	if v <= 0 {
+		return nil
+	}
+	x := int16(v)
+	return &x
+}

--- a/gophergate-wg-agent/pkg/cobraCLI/create.go
+++ b/gophergate-wg-agent/pkg/cobraCLI/create.go
@@ -50,6 +50,15 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// persist to DB
+		if DB == nil {
+			errf(cmd, "Error: database no initialied; cannot persist peer\n")
+			Log.Errorw("create failed: DB not intialised", "iface", createIface, "name", createName, "pubKey", createPubKey)
+			return errors.New("database not initialised")
+		}
+
+		repo := data.NewRepository(DB)
+
 		req := wgsvc.CreatePeerRequest{
 			Iface:             createIface,
 			Name:              createName,
@@ -58,6 +67,7 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 			Endpoint:          createEndpoint,
 			KeepaliveSeconds:  createKeepalive,
 			ReplaceAllowedIPs: createReplaceIPs,
+			Repo:              repo,
 		}
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 8*time.Second)
@@ -75,34 +85,14 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 			return err
 		}
 
-		// persist to DB
-		if DB == nil {
-			errf(cmd, "Error: database no initialied; cannot persist peer\n")
-			Log.Errorw("create failed: DB not intialised", "iface", createIface, "name", createName, "pubKey", createPubKey)
-			return errors.New("database not initialised")
-		}
-
 		primaryIP := pickPrimaryIP(createAllowed)
-		repo := data.NewRepository(DB)
-		id, err := repo.Insert(ctx, data.Peer{
-			Name:                createName,
-			PublicKey:           createPubKey,
-			IPAddress:           primaryIP,
-			Endpoint:            optionalString(createEndpoint),
-			PersistentKeepalive: optionalI16(createKeepalive),
-		})
-		if err != nil {
-			errf(cmd, "Error: failed to insert peer in DB: %v\n", err)
-			Log.Errorw("insert peer failed", "iface", createIface, "name", createName, "pubKey", createPubKey, "err", err)
-			return fmt.Errorf("insert peer: %w", err)
-		}
 
 		outf(cmd, "Peer created on %s\n ID: %s\n Name: %s\n PublicKey: %s\n PrimaryIP: %s\n ConfigApplied: %t\n",
-			resp.Iface, id, resp.Name, resp.PublicKey, primaryIP, resp.ConfigApplied,
+			resp.Iface, resp.ID, resp.Name, resp.PublicKey, primaryIP, resp.ConfigApplied,
 		)
 
 		Log.Infow("peerCreated",
-			"id", id,
+			"id", resp.ID,
 			"name", resp.Name,
 			"iface", resp.Iface,
 			"pubKey", resp.PublicKey,
@@ -158,19 +148,4 @@ func pickPrimaryIP(cidrs []string) net.IP {
 		}
 	}
 	return nil
-}
-
-func optionalString(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
-}
-
-func optionalI16(v int) *int16 {
-	if v <= 0 {
-		return nil
-	}
-	x := int16(v)
-	return &x
 }

--- a/gophergate-wg-agent/pkg/cobraCLI/delete.go
+++ b/gophergate-wg-agent/pkg/cobraCLI/delete.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/wgsvc"
-	"github.com/jackc/pgx/v5"
 	"github.com/spf13/cobra"
 )
 
@@ -74,6 +73,7 @@ var deleteCmd = &cobra.Command{
 		req := wgsvc.DeletePeerRequest{
 			Iface:     delIface,
 			PublicKey: pubKey,
+			Repo:      repo,
 		}
 
 		resp, err := wgsvc.DeletePeer(ctx, req)
@@ -86,16 +86,6 @@ var deleteCmd = &cobra.Command{
 				Log.Errorw("delete peer failed", "iface", delIface, "err", err)
 			}
 			return err
-		}
-
-		if _, err := repo.DeleteByPublicKey(ctx, pubKey); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				outf(cmd, "Note: no DB row matched for %s; removed from interface only\n", pubKey)
-				Log.Warnw("no DB row matched; removed from interface only", "pubKey", pubKey)
-			} else {
-				outf(cmd, "Warning: failed to delete peer from DB: %v\n", err)
-				Log.Errorw("failed to delete peer from DB", "pubKey", pubKey, "err", err)
-			}
 		}
 
 		outf(cmd, "Peer removed on %s: %s\n", resp.Iface, resp.PublicKey)

--- a/gophergate-wg-agent/pkg/cobraCLI/edit.go
+++ b/gophergate-wg-agent/pkg/cobraCLI/edit.go
@@ -77,32 +77,13 @@ Specify either --pubkey or --name (name resovles via DB). If both are provided, 
 
 		var kaPtr *int
 		if upKeepaliveSet {
-			if upKeepalive > 0 {
-				ka := upKeepalive
-				kaPtr = &ka
-			} else {
-				kaPtr = nil
-			}
+			ka := upKeepalive
+			kaPtr = &ka
 		}
 
-		var endpointPtr *string
-		setEndpoint := false
-		if cmd.Flags().Changed("endpoint") {
-			setEndpoint = true
-			if strings.TrimSpace(upEndpoint) == "" {
-				endpointPtr = nil
-			} else {
-				ep := upEndpoint
-				endpointPtr = &ep
-			}
-		}
-
-		dbIn := data.UpdatePeerDBInput{
-			ReplaceAllowed: upSetAllowed,
-			AppendAllowed:  upAppendAllowed,
-			SetEndpoint:    setEndpoint,
-			Endpoint:       endpointPtr,
-			SetKeepalive:   upKeepaliveSet,
+		endpoint := ""
+		if cmd.Flags().Changed("endpoint") && strings.TrimSpace(upEndpoint) != "" {
+			endpoint = upEndpoint
 		}
 
 		req := wgsvc.UpdatePeerRequest{
@@ -110,8 +91,9 @@ Specify either --pubkey or --name (name resovles via DB). If both are provided, 
 			PublicKey:          pubKey,
 			SetAllowedCIDRs:    upSetAllowed,
 			AppendAllowedCIDRs: upAppendAllowed,
-			Endpoint:           upEndpoint,
+			Endpoint:           endpoint,
 			KeepaliveSeconds:   kaPtr,
+			Repo:               repo,
 		}
 
 		resp, err := wgsvc.UpdatePeer(ctx, req)
@@ -124,17 +106,6 @@ Specify either --pubkey or --name (name resovles via DB). If both are provided, 
 				Log.Errorw("update peer failed", "iface", upIface, "err", err)
 			}
 			return err
-		}
-
-		if kaPtr != nil {
-			ka16 := int16(*kaPtr)
-			dbIn.Keepalive = &ka16
-		} else if upKeepaliveSet {
-			dbIn.Keepalive = nil
-		}
-		if _, err := repo.UpdateByPublicKey(ctx, pubKey, dbIn); err != nil {
-			errf(cmd, "Warning: failed to sync DB: %v\n", err)
-			Log.Errorw("failed to syunc DB after kernal update", "pubKey", pubKey, "err", err)
 		}
 
 		if upAsJSON {

--- a/gophergate-wg-agent/pkg/cobraCLI/serve.go
+++ b/gophergate-wg-agent/pkg/cobraCLI/serve.go
@@ -1,6 +1,8 @@
 package cobraCLI
 
 import (
+	"errors"
+
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/grpcserver"
 	"github.com/spf13/cobra"
 )
@@ -10,7 +12,10 @@ func newServeCmd() *cobra.Command {
 		Use:   "serve",
 		Short: "Start gRPC server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return grpcserver.Start(Log)
+			if DB == nil {
+				return errors.New("database not initialised; cannot start gRPC server")
+			}
+			return grpcserver.Start(Log, DB)
 		},
 	}
 }


### PR DESCRIPTION
## Description
Added database persistence to grpc and also refactoring the cli logic so to have 1 single source of truth for database persistence.

## Related Issue(s) and PR(s)
- Closes #101 

## Changes Made

- Added database persistence to `create` function
- Added database persistence to `delete` function
- Added database persistence to `update` function

## Additional Notes
Done with testing on dev environment. Everything seems to be working fine.