### PR TITLE
chore: Bump lint action version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,7 +52,7 @@ jobs:
           ls -la "${{ matrix.module }}"
 
       - name: Set up Go from module
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.module }}/go.mod
           cache: false
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           working-directory: ${{ matrix.module }}
           version: latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -71,5 +71,5 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           working-directory: ${{ matrix.module }}
-          version: latest
+          version: v2.11.4
           args: --timeout=5m


### PR DESCRIPTION
## Description
Updates the lint GitHub Actions workflow to use a newer `golangci-lint` action and pinned linter version from Go version compatibility.

## Related Issue(s) and PR(s)
- NA

## Changes Made
- Bumped `golangci/golangci-lint-action` from `v6` to `v9`
- Pinned `golangci-lint` to a v2 release instead of using `latest`
- Preserved the current lint arguments and workflow logic

## Additional Notes
This is a chore update to fix CI linting compatibility with newer Go versions.