### PR TITLE
chore: Bump Dockerfile version

### DIFF
--- a/gophergate-ui/Dockerfile
+++ b/gophergate-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
     -o /out/ui ./cmd/ui
 
 # runtime 
-FROM alpine:3.20
+FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates \
     && adduser -D -H -u 65532 nonroot \


### PR DESCRIPTION
## Description
Update the Go base image in the `gophergate-ui` Dockerfile from `golang:1.24-alpine` to `golang:1.25-alpine` to match the `go 1.25.0` requirement specified in `go.mod`. This resolves the CI/CD build failure caused by the Go version mismatch.

## Related Issue(s) and PR(s)
- NA

## Changes Made
- Updated `gophergate-ui/Dockerfile` builder stage base image from `golang:1.24-alpine` to `golang:1.25-alpine`
- Updated runtime stage base image from `alpine3.20` to `alpine:3.21` for latest security patches

## Additional Notes
Build was failing because `go.mod` requires `go >= 1.25.0` but the Dockerfile was using `golang:1.24-alpine` (Go1.24.13). Bumping the base image to `golang:1.25-alpine` resolves the mismatch.