### PR TITLE
fix: Fixed linting issues

### DIFF
--- a/gophergate-wg-agent/internal/wgsvc/delete.go
+++ b/gophergate-wg-agent/internal/wgsvc/delete.go
@@ -22,7 +22,7 @@ func DeletePeer(ctx context.Context, req DeletePeerRequest) (DeletePeerResponse,
 	if err != nil {
 		return DeletePeerResponse{}, fmt.Errorf("wgctrl new: %w", err)
 	}
-	defer cli.Close()
+	defer func() { _ = cli.Close() }()
 
 	pub, err := wgtypes.ParseKey(req.PublicKey)
 	if err != nil {

--- a/gophergate-wg-agent/internal/wgsvc/get.go
+++ b/gophergate-wg-agent/internal/wgsvc/get.go
@@ -12,7 +12,7 @@ func GetPeerByPublicKey(iface, pubkey string) (*PeerStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("wgctrl init error: %w", err)
 	}
-	defer ctx.Close()
+	defer func() { _ = ctx.Close() }()
 
 	dev, err := ctx.Device(iface)
 	if err != nil {

--- a/gophergate-wg-agent/internal/wgsvc/list.go
+++ b/gophergate-wg-agent/internal/wgsvc/list.go
@@ -15,7 +15,7 @@ func ListPeers(iface string) ([]PeerStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("wgctrl new: %w", err)
 	}
-	defer cli.Close()
+	defer func() { _ = cli.Close() }()
 
 	dev, err := cli.Device(iface)
 	if err != nil {

--- a/gophergate-wg-agent/pkg/cobraCLI/io.go
+++ b/gophergate-wg-agent/pkg/cobraCLI/io.go
@@ -6,7 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func out(cmd *cobra.Command, s string)            { fmt.Fprint(cmd.OutOrStdout(), s) }
-func outf(cmd *cobra.Command, f string, a ...any) { fmt.Fprintf(cmd.OutOrStdout(), f, a...) }
+func out(cmd *cobra.Command, s string) {
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), s)
+}
 
-func errf(cmd *cobra.Command, f string, a ...any) { fmt.Fprintf(cmd.ErrOrStderr(), f, a...) }
+func outf(cmd *cobra.Command, f string, a ...any) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), f, a...)
+}
+
+func errf(cmd *cobra.Command, f string, a ...any) {
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), f, a...)
+}


### PR DESCRIPTION
## Description
Fixes `golangci-lint` `errcheck`  issues in the WireGuard agent by properly handling previously ignored error returned values.

## Related Issue(s) and PR(s)
- NA

## Changes Made
- Wrapped deferred `Close()` calls to handle returned errors
- Updated Cobra CLI IO helpers to explicitly handle/discard `fmt.Fprint` and `fmt.Fprintf` return values
- Resolved `golangci-lint` `errcheck` findings in affected files

## Additional Notes
- No functional changes intended
- This is a lint/compliance cleanup to keep CI passing