### PR TITLE
refactor: Fix dockerfile not building with static css

### DIFF
--- a/gophergate-ui/Dockerfile
+++ b/gophergate-ui/Dockerfile
@@ -2,12 +2,17 @@ FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 
-RUN apk add --no-cache ca-certificates git
+RUN apk add --no-cache ca-certificates git nodejs npm
 
 COPY ./go.mod ./go.sum ./
 RUN go mod download -x
 
+COPY package.json package-lock.json ./
+RUN npm ci
+
 COPY . .
+
+RUN npm run build:css
 
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
     -o /out/ui ./cmd/ui


### PR DESCRIPTION
## Description
This PR updates the GopherGate UI Dockerfile to run `npm run build:css` during the image build process so the compiled `styles.css` file is included in the container.

## Related Issue(s) and PR(s)
- NA

## Changes Made
- Updated the UI Dockerfile
- Added `npm run build:css` to the build process
- Ensured static `styles.css` is generated during container build
   
## Additional Notes
This change helps make sure the required compiled CSS assets are available in the built image for deployment.