### PR TITLE
refactor: Removed arm/v7 since we will stop supporting 32 bit systems

### DIFF
--- a/.github/workflows/docker-on-release-merge.yaml
+++ b/.github/workflows/docker-on-release-merge.yaml
@@ -1,146 +1,146 @@
 name: docker-build-on-release-merge
 
 on:
-    pull_request:
-        branches: [dev]
-        types: [closed]
-    workflow_dispatch: {}
+  pull_request:
+    branches: [dev]
+    types: [closed]
+  workflow_dispatch: {}
 
 permissions:
-    contents: write
+  contents: write
 
 jobs:
-    guard:
-        runs-on: ubuntu-latest
-        outputs:
-            ok: ${{ steps.chk.outputs.ok }}
-            head_ref: ${{ steps.chk.outputs.head_ref }}
-            base_ref: ${{ steps.chk.outputs.base_ref }}
-        steps:
-            - id: chk
-              shell: bash
-              run: |
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.chk.outputs.ok }}
+      head_ref: ${{ steps.chk.outputs.head_ref }}
+      base_ref: ${{ steps.chk.outputs.base_ref }}
+    steps:
+      - id: chk
+        shell: bash
+        run: |
 
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                    echo "ok=false" >> "$GITHUB_OUTPUT"
-                    echo "head_ref=" >> "$GITHUB_OUTPUT}"
-                    echo "base_ref=" >> "$GITHUB_OUTPUT"
-                    echo "Manual trigger is enabled but not supported by this workflow without inputs."
-                    exit 0
-                  fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "head_ref=" >> "$GITHUB_OUTPUT}"
+            echo "base_ref=" >> "$GITHUB_OUTPUT"
+            echo "Manual trigger is enabled but not supported by this workflow without inputs."
+            exit 0
+          fi
 
-                  if [ "${{ github.event_name }}" != "pull_request" ]; then
-                    echo "ok=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-                  if [ "${{ github.event.pull_request.merged }}" != "true" ]; then
-                    echo "ok=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
+          if [ "${{ github.event.pull_request.merged }}" != "true" ]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-                  BASE="${{ github.event.pull_request.base.ref }}"
-                  HEAD="${{ github.event.pull_request.head.ref }}"
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
 
-                  echo "base_ref=$BASE" >> "$GITHUB_OUTPUT"
-                  echo "head_ref=$HEAD" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD" >> "$GITHUB_OUTPUT"
 
-                  if [ "$BASE" != "dev" ]; then
-                    echo "ok=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
+          if [ "$BASE" != "dev" ]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-                  if [[ "$HEAD" != release/* ]]; then
-                    echo "ok=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
+          if [[ "$HEAD" != release/* ]]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-                  echo "ok=true" >> "$GITHUB_OUTPUT"
+          echo "ok=true" >> "$GITHUB_OUTPUT"
 
-    docker:
-        needs: guard
-        if: ${{ needs.guard.outputs.ok == 'true' }}
-        runs-on: ubuntu-latest
+  docker:
+    needs: guard
+    if: ${{ needs.guard.outputs.ok == 'true' }}
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Parse release branch
-              id: parse
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  BR="${{ github.event.pull_request.head.ref }}"
-                  if [[ "$BR" =~ ^release/([^/]+)/v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-                    MOD="${BASH_REMATCH[1]}"
-                    VER="${BASH_REMATCH[2]}"
-                    echo "module_path=$MOD" >> "$GITHUB_OUTPUT"
-                    echo "version=$VER" >> "$GITHUB_OUTPUT"
-                    echo "Parsed module=$MOD version=$VER"
-                  else
-                    echo "Branch name not in expected format: $BR"
-                    echo "Expected: release/<module>/vX.Y.Z"
-                    exit 1
-                  fi
+    steps:
+      - name: Parse release branch
+        id: parse
+        shell: bash
+        run: |
+          set -euo pipefail
+          BR="${{ github.event.pull_request.head.ref }}"
+          if [[ "$BR" =~ ^release/([^/]+)/v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            MOD="${BASH_REMATCH[1]}"
+            VER="${BASH_REMATCH[2]}"
+            echo "module_path=$MOD" >> "$GITHUB_OUTPUT"
+            echo "version=$VER" >> "$GITHUB_OUTPUT"
+            echo "Parsed module=$MOD version=$VER"
+          else
+            echo "Branch name not in expected format: $BR"
+            echo "Expected: release/<module>/vX.Y.Z"
+            exit 1
+          fi
 
-            - name: Decide if this module publishes Docker
-              id: decide
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  MOD="${{ steps.parse.outputs.module_path }}"
-                  case "$MOD" in
-                    gophergate-wg-agent|gophergate-ui)
-                      echo "publish=true" >> "$GITHUB_OUTPUT"
-                      ;;
-                    *)
-                      echo "publish=false" >> "$GITHUB_OUTPUT"
-                      ;;
-                  esac
+      - name: Decide if this module publishes Docker
+        id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+          MOD="${{ steps.parse.outputs.module_path }}"
+          case "$MOD" in
+            gophergate-wg-agent|gophergate-ui)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
-            - uses: actions/checkout@v4
-              if: ${{ steps.decide.outputs.publish == 'true' }}
-              with:
-                  fetch-depth: 0
+      - uses: actions/checkout@v4
+        if: ${{ steps.decide.outputs.publish == 'true' }}
+        with:
+          fetch-depth: 0
 
-            - name: Set up QEMU
-              if: ${{ steps.decide.outputs.publish == 'true' }}
-              uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        if: ${{ steps.decide.outputs.publish == 'true' }}
+        uses: docker/setup-qemu-action@v3
 
-            - name: Set up Docker Buildx
-              if: ${{ steps.decide.outputs.publish == 'true' }}
-              uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        if: ${{ steps.decide.outputs.publish == 'true' }}
+        uses: docker/setup-buildx-action@v3
 
-            - name: Login to Docker Hub
-              if: ${{ steps.decide.outputs.publish == 'true' }}
-              uses: docker/login-action@v3
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_PAT }}
+      - name: Login to Docker Hub
+        if: ${{ steps.decide.outputs.publish == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
-            - name: Docker meta (single repo, module+version tags)
-              id: meta
-              if: ${{ steps.decide.outputs.publish == 'true' }}
-              uses: docker/metadata-action@v5
-              with:
-                  images: |
-                      cyrof/gophergate
-                  tags: |
-                      type=raw,value=${{ steps.parse.outputs.module_path }}-v${{ steps.parse.outputs.version}}
-                      type=raw,value=${{ steps.parse.outputs.module_path }}-latest
+      - name: Docker meta (single repo, module+version tags)
+        id: meta
+        if: ${{ steps.decide.outputs.publish == 'true' }}
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            cyrof/gophergate
+          tags: |
+            type=raw,value=${{ steps.parse.outputs.module_path }}-v${{ steps.parse.outputs.version}}
+            type=raw,value=${{ steps.parse.outputs.module_path }}-latest
 
-            - name: Build & push (multi-arch)
-              if: ${{ steps.decide.outputs.publish == 'true' }}
-              uses: docker/build-push-action@v6
-              with:
-                  context: ./${{ steps.parse.outputs.module_path }}
-                  file: ./${{ steps.parse.outputs.module_path }}/Dockerfile
-                  push: true
-                  platforms: linux/amd64,linux/arm/v7,linux/arm64
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+      - name: Build & push (multi-arch)
+        if: ${{ steps.decide.outputs.publish == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ steps.parse.outputs.module_path }}
+          file: ./${{ steps.parse.outputs.module_path }}/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-            - name: Skip notice
-              if: ${{ steps.decide.outputs.publish != 'true' }}
-              run: |
-                  echo "Module '${{ steps.parse.outputs.module_path }}' is not configured for Docker publishing. Skipping."
+      - name: Skip notice
+        if: ${{ steps.decide.outputs.publish != 'true' }}
+        run: |
+          echo "Module '${{ steps.parse.outputs.module_path }}' is not configured for Docker publishing. Skipping."


### PR DESCRIPTION
## Description

This PR removes `arm/v7` support from the build and release process as we will no longer support 32-bit systems.

## Related Issue(s) and PR(s)

- NA

## Changes Made

- Removed `arm/v7` from the supported build targets
- Updated the release process to align with supported architectures only

## Additional Notes

This change simplifies the build pipeline and reflects the current supported platform scope.