### PR TITLE
Add peer traffic snapshot backend support to wg-agent 

### DIFF
--- a/gophergate-wg-agent/go.mod
+++ b/gophergate-wg-agent/go.mod
@@ -3,8 +3,8 @@ module github.com/Cyrof/GopherGate/gophergate-wg-agent
 go 1.25.0
 
 require (
-	github.com/Cyrof/GopherGate/gophergate-core v0.5.0
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/Cyrof/GopherGate/gophergate-core v0.6.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
@@ -19,7 +19,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mdlayher/genetlink v1.4.0 // indirect
-	github.com/mdlayher/netlink v1.11.0 // indirect
+	github.com/mdlayher/netlink v1.11.1 // indirect
 	github.com/mdlayher/socket v0.6.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -29,7 +29,7 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20250521234502-f333402bd9cb // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/gophergate-wg-agent/go.sum
+++ b/gophergate-wg-agent/go.sum
@@ -4,6 +4,8 @@ github.com/Cyrof/GopherGate/gophergate-core v0.4.1 h1:tHrkiqp9ny2aFaD8SbJy/SZhTG
 github.com/Cyrof/GopherGate/gophergate-core v0.4.1/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
 github.com/Cyrof/GopherGate/gophergate-core v0.5.0 h1:CRxBx6D/YhUCu/Xwfp7dBgJn+HuiH4aVu+5e2xS5jZw=
 github.com/Cyrof/GopherGate/gophergate-core v0.5.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
+github.com/Cyrof/GopherGate/gophergate-core v0.6.0 h1:qkjR+J96/zoq1NXBEgpJAQRf41KnapgmtOXJKAHSxuA=
+github.com/Cyrof/GopherGate/gophergate-core v0.6.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -20,6 +22,8 @@ github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
 github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
 github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
 github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
@@ -32,6 +36,8 @@ github.com/mdlayher/netlink v1.8.0 h1:e7XNIYJKD7hUct3Px04RuIGJbBxy1/c4nX7D5Yyvvl
 github.com/mdlayher/netlink v1.8.0/go.mod h1:UhgKXUlDQhzb09DrCl2GuRNEglHmhYoWAHid9HK3594=
 github.com/mdlayher/netlink v1.11.0 h1:Cot7ixQZL6P/pxRFB4z3jRdGPYeZosFT+WHS3sMXy8Y=
 github.com/mdlayher/netlink v1.11.0/go.mod h1:rMwDzh42W85uW3yTtiTRZFX9uway98aDQ5i+D8Jq4g4=
+github.com/mdlayher/netlink v1.11.1 h1:T136gDS6Gkt+hLncaBwKdW5GpEC8Z0ykqimOebVoal0=
+github.com/mdlayher/netlink v1.11.1/go.mod h1:ao4LjamyK4Uq9L8+fQzqFYpAncbeCdwbvd9Edv/pYnc=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/mdlayher/socket v0.6.0 h1:ScZPaAGyO1icQnbFrhPM8mnXyMu9qukC1K4ZoM2IQKU=
@@ -100,6 +106,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d h1:wT2n40TBqFY6wiwazVK9/iTWbsQrgk5ZfCSVFLO9LQA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.77.0 h1:wVVY6/8cGA6vvffn+wWK5ToddbgdU3d8MNENr4evgXM=
 google.golang.org/grpc v1.77.0/go.mod h1:z0BY1iVj0q8E1uSQCjL9cppRj+gnZjzDnzV0dHhrNig=
 google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=

--- a/gophergate-wg-agent/internal/data/model.go
+++ b/gophergate-wg-agent/internal/data/model.go
@@ -42,3 +42,20 @@ type BootstrapPeer struct {
 	Keepalive *int16
 	Name      string
 }
+
+type PeerTrafficSnapshot struct {
+	ID         string
+	Iface      string
+	PublicKey  string
+	RXBytes    uint64
+	TXBytes    uint64
+	TotalBytes uint64
+	RecordedAt time.Time
+}
+
+type PeerTrafficPoint struct {
+	Timestamp  time.Time
+	RXBytes    uint64
+	TXBytes    uint64
+	TotalBytes uint64
+}

--- a/gophergate-wg-agent/internal/data/traffic.go
+++ b/gophergate-wg-agent/internal/data/traffic.go
@@ -1,0 +1,75 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func (r *Repository) InsertPeerTrafficSnapshot(ctx context.Context, s PeerTrafficSnapshot) error {
+	const q = `
+		insert into peer_traffic_snapshots (iface, public_key, rx_bytes, tx_bytes, total_bytes, recorded_at)
+		values ($1, $2, $3, $4, $5, $6);
+	`
+	_, err := r.db.Exec(ctx, q,
+		s.Iface,
+		s.PublicKey,
+		int64(s.RXBytes),
+		int64(s.TXBytes),
+		int64(s.TotalBytes),
+		s.RecordedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert peer traffic snapshot: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) ListPeerTrafficPoints(ctx context.Context, iface, publicKey string, since time.Time) ([]PeerTrafficPoint, error) {
+	const q = `
+		select recorded_at, rx_bytes, tx_bytes, total_bytes
+		from peer_traffic_snapshots
+		where iface = $1
+		  and public_key = $2
+		  and recorded_at >= $3
+		order by recorded_at asc;
+	`
+
+	rows, err := r.db.Query(ctx, q, iface, publicKey, since)
+	if err != nil {
+		return nil, fmt.Errorf("list peer traffic points: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PeerTrafficPoint
+	for rows.Next() {
+		var p PeerTrafficPoint
+		var rx, tx, total int64
+		if err := rows.Scan(&p.Timestamp, &rx, &tx, &total); err != nil {
+			return nil, fmt.Errorf("scan peer traffic point: %w", err)
+		}
+		p.RXBytes = uint64(rx)
+		p.TXBytes = uint64(tx)
+		p.TotalBytes = uint64(total)
+		out = append(out, p)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate peer traffic points: %w", err)
+	}
+
+	return out, nil
+}
+
+func (r *Repository) DeletePeerTrafficOlderThan(ctx context.Context, cutoff time.Time) error {
+	const q = `
+		delete from peer_traffic_snapshots
+		where recorded_at < $1;
+	`
+
+	_, err := r.db.Exec(ctx, q, cutoff)
+	if err != nil {
+		return fmt.Errorf("delete old peer traffic snapshots: %w", err)
+	}
+	return nil
+}

--- a/gophergate-wg-agent/internal/grpcserver/server.go
+++ b/gophergate-wg-agent/internal/grpcserver/server.go
@@ -1,8 +1,11 @@
 package grpcserver
 
 import (
+	"context"
 	"net"
 	"os"
+	"strconv"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -10,12 +13,31 @@ import (
 	gatewayv1 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v1"
 	gatewayv2 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v2"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/service"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func envOrDefault(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return def
+}
+
+func envIntOrDefault(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if d, err := strconv.Atoi(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+func envDurationOrDefault(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
 	}
 	return def
 }
@@ -40,6 +62,23 @@ func Start(logger *zap.SugaredLogger, pool *pgxpool.Pool) error {
 
 	gatewayv1.RegisterWireGuardServiceServer(srv, NewWireGuardService(repo))
 	gatewayv2.RegisterWireGuardServiceServer(srv, NewWireGuardServiceV2(repo))
+
+	if repo != nil {
+		iface := envOrDefault("WG_IFACE", "wg0")
+		snapshotInterval := envDurationOrDefault("TRAFFIC_SNAPSHOT_INTERVAL", time.Minute)
+		retentionDays := envIntOrDefault("TRAFFIC_RETENTION_DAYS", 3)
+
+		trafficSvc := service.NewTrafficService(repo)
+		snapshotter := service.NewTrafficSnapshotter(
+			trafficSvc,
+			iface,
+			snapshotInterval,
+			retentionDays,
+			logger,
+		)
+
+		go snapshotter.Run(context.Background())
+	}
 
 	logger.Infow("grpc server started", "addr", listenAddr)
 	return srv.Serve(list)

--- a/gophergate-wg-agent/internal/grpcserver/wireguard_v2.go
+++ b/gophergate-wg-agent/internal/grpcserver/wireguard_v2.go
@@ -3,6 +3,7 @@ package grpcserver
 import (
 	"context"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,12 +18,14 @@ type WireGuardServiceV2 struct {
 	gatewayv2.UnimplementedWireGuardServiceServer
 	repo         *data.Repository
 	dashboardSvc *service.DashboardService
+	trafficSvc   *service.TrafficService
 }
 
 func NewWireGuardServiceV2(repo *data.Repository) *WireGuardServiceV2 {
 	return &WireGuardServiceV2{
 		repo:         repo,
 		dashboardSvc: service.NewDashboardService(repo),
+		trafficSvc:   service.NewTrafficService(repo),
 	}
 }
 
@@ -100,6 +103,31 @@ func mapDashboardToProto(in *service.DashboardResult) *gatewayv2.GetDashboardRes
 	return out
 }
 
+func mapPeerTrafficToProto(in *service.PeerTrafficHistoryResult) *gatewayv2.GetPeerTrafficResponse {
+	if in == nil {
+		return &gatewayv2.GetPeerTrafficResponse{}
+	}
+
+	out := &gatewayv2.GetPeerTrafficResponse{
+		Traffic: &gatewayv2.PeerTrafficHistory{
+			PublicKey: in.PublicKey,
+			Name:      in.Name,
+			Points:    make([]*gatewayv2.PeerTrafficPoint, 0, len(in.Points)),
+		},
+	}
+
+	for _, p := range in.Points {
+		out.Traffic.Points = append(out.Traffic.Points, &gatewayv2.PeerTrafficPoint{
+			Timestamp:  p.Timestamp.UTC().Format(time.RFC3339),
+			RxBytes:    p.RXBytes,
+			TxBytes:    p.TXBytes,
+			TotalBytes: p.TotalBytes,
+		})
+	}
+
+	return out
+}
+
 func (s *WireGuardServiceV2) GetDashboard(
 	ctx context.Context,
 	req *gatewayv2.GetDashboardRequest,
@@ -114,6 +142,33 @@ func (s *WireGuardServiceV2) GetDashboard(
 	}
 
 	return mapDashboardToProto(result), nil
+}
+
+func (s *WireGuardServiceV2) GetPeerTraffic(
+	ctx context.Context,
+	req *gatewayv2.GetPeerTrafficRequest,
+) (*gatewayv2.GetPeerTrafficResponse, error) {
+	if req.GetIface() == "" {
+		return nil, status.Error(codes.InvalidArgument, "iface is required")
+	}
+	if req.GetPublicKey() == "" {
+		return nil, status.Error(codes.InvalidArgument, "public_key is required")
+	}
+
+	rangeName := req.GetRange()
+	if rangeName == "" {
+		rangeName = "24h"
+	}
+
+	result, err := s.trafficSvc.GetPeerTrafficHistory(ctx, req.GetIface(), req.GetPublicKey(), rangeName)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "unsupported range") {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		return nil, status.Errorf(codes.Internal, "get peer traffic: %v", err)
+	}
+
+	return mapPeerTrafficToProto(result), nil
 }
 
 func (s *WireGuardServiceV2) CreatePeer(

--- a/gophergate-wg-agent/internal/schema/migration/0002_create_peer_traffic_snapshots.up.sql
+++ b/gophergate-wg-agent/internal/schema/migration/0002_create_peer_traffic_snapshots.up.sql
@@ -1,0 +1,13 @@
+create table if not exists peer_traffic_snapshots (
+  id uuid primary key default uuid_generate_v4 (),
+  iface text not null,
+  public_key text not null,
+  rx_bytes bigint not null,
+  tx_bytes bigint not null,
+  total_bytes bigint not null,
+  recorded_at timestamptz not null default now ()
+);
+
+create index if not exists idx_peer_traffic_snapshots_peer_time on peer_traffic_snapshots (public_key, recorded_at desc);
+
+create index if not exists idx_peer_traffic_snapshots_iface_time on peer_traffic_snapshots (iface, recorded_at desc);

--- a/gophergate-wg-agent/internal/service/traffic.go
+++ b/gophergate-wg-agent/internal/service/traffic.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/wgsvc"
+)
+
+type TrafficService struct {
+	repo *data.Repository
+}
+
+func NewTrafficService(repo *data.Repository) *TrafficService {
+	return &TrafficService{repo: repo}
+}
+
+func (s *TrafficService) CapturePeerTrafficSnapshot(ctx context.Context, iface string) error {
+	if s.repo == nil {
+		return fmt.Errorf("repository is nil")
+	}
+	if iface == "" {
+		return fmt.Errorf("iface is required")
+	}
+
+	peers, err := wgsvc.ListPeers(iface)
+	if err != nil {
+		return fmt.Errorf("list peers: %w", err)
+	}
+
+	now := time.Now().UTC()
+	for _, p := range peers {
+		err := s.repo.InsertPeerTrafficSnapshot(ctx, data.PeerTrafficSnapshot{
+			Iface:      iface,
+			PublicKey:  p.PublicKey,
+			RXBytes:    p.RxBytes,
+			TXBytes:    p.TxBytes,
+			TotalBytes: p.RxBytes + p.TxBytes,
+			RecordedAt: now,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type PeerTrafficHistoryResult struct {
+	PublicKey string
+	Name      string
+	Points    []data.PeerTrafficPoint
+}
+
+func (s *TrafficService) GetPeerTrafficHistory(ctx context.Context, iface, publicKey, rangeName string) (*PeerTrafficHistoryResult, error) {
+	if s.repo == nil {
+		return nil, fmt.Errorf("repository is nil")
+	}
+	if iface == "" {
+		return nil, fmt.Errorf("iface is required")
+	}
+	if publicKey == "" {
+		return nil, fmt.Errorf("public_key is required")
+	}
+
+	since := time.Now().UTC().Add(-24 * time.Hour)
+	if rangeName != "" && rangeName != "24h" {
+		return nil, fmt.Errorf("unsupported range: %s", rangeName)
+	}
+
+	points, err := s.repo.ListPeerTrafficPoints(ctx, iface, publicKey, since)
+	if err != nil {
+		return nil, err
+	}
+
+	name := ""
+	if peer, err := s.repo.GetByPublicKey(ctx, publicKey); err == nil && peer != nil {
+		name = peer.Name
+	}
+
+	return &PeerTrafficHistoryResult{
+		PublicKey: publicKey,
+		Name:      name,
+		Points:    points,
+	}, nil
+}
+
+func (s *TrafficService) CleanupOldPeerTraffic(ctx context.Context, retentionDays int) error {
+	if s.repo == nil {
+		return fmt.Errorf("repository is nil")
+	}
+	if retentionDays <= 0 {
+		return fmt.Errorf("retentionDays must be > 0")
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+	return s.repo.DeletePeerTrafficOlderThan(ctx, cutoff)
+}

--- a/gophergate-wg-agent/internal/service/traffic_snapshotter.go
+++ b/gophergate-wg-agent/internal/service/traffic_snapshotter.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type TrafficSnapshotter struct {
+	trafficSvc    *TrafficService
+	iface         string
+	interval      time.Duration
+	retentionDays int
+	log           *zap.SugaredLogger
+}
+
+func NewTrafficSnapshotter(
+	trafficSvc *TrafficService,
+	iface string,
+	interval time.Duration,
+	retentionDays int,
+	log *zap.SugaredLogger,
+) *TrafficSnapshotter {
+	return &TrafficSnapshotter{
+		trafficSvc:    trafficSvc,
+		iface:         iface,
+		interval:      interval,
+		retentionDays: retentionDays,
+		log:           log,
+	}
+}
+
+func (s *TrafficSnapshotter) Run(ctx context.Context) {
+	if s.trafficSvc == nil {
+		if s.log != nil {
+			s.log.Warn("traffic snapshotter disabled: traffic service is nil")
+		}
+		return
+	}
+	if s.iface == "" {
+		s.iface = "wg0"
+	}
+	if s.interval <= 0 {
+		s.interval = time.Minute
+	}
+	if s.retentionDays <= 0 {
+		s.retentionDays = 3
+	}
+
+	if s.log != nil {
+		s.log.Infow(
+			"traffic snapshotter started",
+			"iface", s.iface,
+			"interval", s.interval.String(),
+			"retention_days", s.retentionDays,
+		)
+	}
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+}
+
+func (s *TrafficSnapshotter) capture(ctx context.Context) {
+	if err := s.trafficSvc.CapturePeerTrafficSnapshot(ctx, s.iface); err != nil {
+		if s.log != nil {
+			s.log.Errorw("traffic snapshot capture failed", "iface", s.iface, "err", err)
+		}
+		return
+	}
+
+	if err := s.trafficSvc.CleanupOldPeerTraffic(ctx, s.retentionDays); err != nil {
+		if s.log != nil {
+			s.log.Errorw("traffic retention cleanup failed", "retention_days", s.retentionDays, "err", err)
+		}
+		return
+	}
+
+	if s.log != nil {
+		s.log.Debugw("traffic snapshot captured", "iface", s.iface)
+	}
+}

--- a/gophergate-wg-agent/internal/service/traffic_snapshotter.go
+++ b/gophergate-wg-agent/internal/service/traffic_snapshotter.go
@@ -60,6 +60,19 @@ func (s *TrafficSnapshotter) Run(ctx context.Context) {
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 
+	s.capture(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if s.log != nil {
+				s.log.Infow("traffic snapshotter stopped", "reason", ctx.Err())
+			}
+			return
+		case <-ticker.C:
+			s.capture(ctx)
+		}
+	}
 }
 
 func (s *TrafficSnapshotter) capture(ctx context.Context) {


### PR DESCRIPTION
## Description

This PR updates `gophergate-wg-agent` to support peer traffic history for the new `v2` flow. It adds backend handling for RX/TX traffic points used for UI graphing, and introduces a snapshotter that periodically stores traffic data in the database for later retrieval.

## Related Issue(s) and PR(s)

- Related to the `gateway/v2` traffic history protobuf PR
- Supports upcoming UI traffic graph integration

## Changes Made

- Added backend support for peer traffic points using RX bytes and TX bytes
- Implemented traffic history handling for UI graphing
- Added a snapshotter to periodically persist traffic data to the database
- Added `.env` support for `TRAFFIC_SNAPSHOT_INTERVAL`
- Added `.env` support for `TRAFFIC_RETENTION_DAYS`
- Set default traffic snapshot interval to `1m`
- Set default traffic retention period to `3` days

## Additional Notes

This PR focuses on the backend side of traffic history support. The stored traffic snapshots will be used by the UI to render peer traffic graphs, while the interval and retention settings can be tuned through environment variables when needed.