### PR TITLE
Use GITHUB_TOKEN for release PR creation

### DIFF
--- a/.github/workflows/_release-one.yaml
+++ b/.github/workflows/_release-one.yaml
@@ -1,211 +1,211 @@
 name: _release-one
 on:
-    workflow_call:
-        inputs:
-            module_path:
-                required: true
-                type: string
-            module_label:
-                required: true
-                type: string
-            bump_override:
-                required: false
-                type: string
-            dry_run:
-                required: false
-                type: boolean
-                default: false
-        outputs:
-            should_release:
-                value: ${{ jobs.release-one.outputs.should_release }}
-            next_version:
-                value: ${{ jobs.release-one.outputs.next }}
-            bump_kind:
-                value: ${{ jobs.release-one.outputs.bump }}
+  workflow_call:
+    inputs:
+      module_path:
+        required: true
+        type: string
+      module_label:
+        required: true
+        type: string
+      bump_override:
+        required: false
+        type: string
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      should_release:
+        value: ${{ jobs.release-one.outputs.should_release }}
+      next_version:
+        value: ${{ jobs.release-one.outputs.next }}
+      bump_kind:
+        value: ${{ jobs.release-one.outputs.bump }}
 
 permissions:
-    contents: write
-    pull-requests: write
+  contents: write
+  pull-requests: write
 
 jobs:
-    release-one:
-        runs-on: ubuntu-latest
-        outputs:
-            should_release: ${{ steps.decide.outputs.should_release }}
-            next: ${{ steps.bump.outputs.next }}
-            bump: ${{ steps.bump.outputs.bump }}
-        steps:
-            - uses: actions/checkout@v4
-              with: { fetch-depth: 0, persist-credentials: false }
+  release-one:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.decide.outputs.should_release }}
+      next: ${{ steps.bump.outputs.next }}
+      bump: ${{ steps.bump.outputs.bump }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, persist-credentials: false }
 
-            - name: Fetch tags
-              run: git fetch --tags --force
+      - name: Fetch tags
+        run: git fetch --tags --force
 
-            - name: Last tag for module
-              id: last
-              run: |
-                  TAG_PREFIX="${{ inputs.module_path }}/v"
-                  LAST_TAG="$(git tag --list "${TAG_PREFIX}*" | sort -V | tail -n1 || true)"
-                  echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
+      - name: Last tag for module
+        id: last
+        run: |
+          TAG_PREFIX="${{ inputs.module_path }}/v"
+          LAST_TAG="$(git tag --list "${TAG_PREFIX}*" | sort -V | tail -n1 || true)"
+          echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
 
-            - name: Commit range
-              id: range
-              run: |
-                  if [ -n "${{ steps.last.outputs.last_tag }}" ]; then
-                    echo "range=${{ steps.last.outputs.last_tag }}..HEAD" >> $GITHUB_OUTPUT
-                  else
-                    FIRST="$(git rev-list --max-parents=0 HEAD | head -n1)"
-                    echo "range=$FIRST..HEAD" >> $GITHUB_OUTPUT
-                  fi
+      - name: Commit range
+        id: range
+        run: |
+          if [ -n "${{ steps.last.outputs.last_tag }}" ]; then
+            echo "range=${{ steps.last.outputs.last_tag }}..HEAD" >> $GITHUB_OUTPUT
+          else
+            FIRST="$(git rev-list --max-parents=0 HEAD | head -n1)"
+            echo "range=$FIRST..HEAD" >> $GITHUB_OUTPUT
+          fi
 
-            - name: Collect messages (module scope)
-              id: msgs
-              run: |
-                  MPATH="${{ inputs.module_path }}"
-                  RANGE="${{ steps.range.outputs.range }}"
-                  git log --pretty=format:%s --no-merges "$RANGE" -- "$MPATH" > /tmp/msgs.txt || true
-                  COUNT="$(wc -l < /tmp/msgs.txt | xargs || true)"
-                  echo "count=$COUNT" >> $GITHUB_OUTPUT
-                  echo "Affected commits: $COUNT"
+      - name: Collect messages (module scope)
+        id: msgs
+        run: |
+          MPATH="${{ inputs.module_path }}"
+          RANGE="${{ steps.range.outputs.range }}"
+          git log --pretty=format:%s --no-merges "$RANGE" -- "$MPATH" > /tmp/msgs.txt || true
+          COUNT="$(wc -l < /tmp/msgs.txt | xargs || true)"
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "Affected commits: $COUNT"
 
-            - name: Decide whether to release
-              id: decide
-              run: |
-                  COUNT="${{ steps.msgs.outputs.count }}"
-                  OVERRIDE="${{ inputs.bump_override }}"
-                  if [ "$COUNT" = "0" ] && [ -z "$OVERRIDE" ]; then
-                    echo "No changes in '${{ inputs.module_path }}' and no bump override. Skipping release."
-                    echo "should_release=false" >> $GITHUB_OUTPUT
-                  else
-                    echo "Changes detected or bump override present. Proceeding."
-                    echo "should_release=true" >> $GITHUB_OUTPUT
-                  fi
+      - name: Decide whether to release
+        id: decide
+        run: |
+          COUNT="${{ steps.msgs.outputs.count }}"
+          OVERRIDE="${{ inputs.bump_override }}"
+          if [ "$COUNT" = "0" ] && [ -z "$OVERRIDE" ]; then
+            echo "No changes in '${{ inputs.module_path }}' and no bump override. Skipping release."
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected or bump override present. Proceeding."
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          fi
 
-            - name: Compute next version
-              id: bump
-              if: ${{ steps.decide.outputs.should_release == 'true' }}
-              run: |
-                  # base version
-                  if [ -n "${{ steps.last.outputs.last_tag }}" ]; then
-                    BASE="${{ steps.last.outputs.last_tag }}"
-                    BASE="${BASE##*/v}"
-                  else
-                    BASE="0.1.0"
-                  fi
-                  IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+      - name: Compute next version
+        id: bump
+        if: ${{ steps.decide.outputs.should_release == 'true' }}
+        run: |
+          # base version
+          if [ -n "${{ steps.last.outputs.last_tag }}" ]; then
+            BASE="${{ steps.last.outputs.last_tag }}"
+            BASE="${BASE##*/v}"
+          else
+            BASE="0.1.0"
+          fi
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
 
-                  # default bump via conventional commits
-                  BUMP="patch"
-                  if grep -Eiq 'BREAKING CHANGE' /tmp/msgs.txt || grep -Eq '^[a-z]+(\([^)]*\))?!:' /tmp/msgs.txt; then
-                    BUMP="major"
-                  elif grep -Eq '^feat(\([^)]*\))?:' /tmp/msgs.txt; then
-                    BUMP="minor" 
-                  fi
+          # default bump via conventional commits
+          BUMP="patch"
+          if grep -Eiq 'BREAKING CHANGE' /tmp/msgs.txt || grep -Eq '^[a-z]+(\([^)]*\))?!:' /tmp/msgs.txt; then
+            BUMP="major"
+          elif grep -Eq '^feat(\([^)]*\))?:' /tmp/msgs.txt; then
+            BUMP="minor" 
+          fi
 
-                  # manual override 
-                  if [ -n "${{ inputs.bump_override }}" ]; then
-                    BUMP="${{ inputs.bump_override}}"
-                  fi
+          # manual override 
+          if [ -n "${{ inputs.bump_override }}" ]; then
+            BUMP="${{ inputs.bump_override}}"
+          fi
 
-                  case "$BUMP" in 
-                    major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0;;
-                    minor) MINOR=$((MINOR+1)); PATCH=0;;
-                    patch) PATCH=$((PATCH+1));;
-                    *) echo "Invalid bump: $BUMP"; exit 1;;
-                  esac
+          case "$BUMP" in 
+            major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0;;
+            minor) MINOR=$((MINOR+1)); PATCH=0;;
+            patch) PATCH=$((PATCH+1));;
+            *) echo "Invalid bump: $BUMP"; exit 1;;
+          esac
 
-                  NEXT="${MAJOR}.${MINOR}.${PATCH}"
-                  echo "bump=$BUMP" >> $GITHUB_OUTPUT
-                  echo "next=$NEXT" >> $GITHUB_OUTPUT
-                  echo "Next: $NEXT ($BUMP)"
+          NEXT="${MAJOR}.${MINOR}.${PATCH}"
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+          echo "Next: $NEXT ($BUMP)"
 
-            - name: Create release branch (local)
-              id: branch
-              if: ${{ steps.decide.outputs.should_release == 'true' }}
-              env:
-                  NEXT: ${{ steps.bump.outputs.next }}
-              run: |
-                  BR="release/${{ inputs.module_path }}/v${NEXT}"
-                  git checkout -b "$BR"
-                  echo "name=$BR" >> $GITHUB_OUTPUT
+      - name: Create release branch (local)
+        id: branch
+        if: ${{ steps.decide.outputs.should_release == 'true' }}
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+        run: |
+          BR="release/${{ inputs.module_path }}/v${NEXT}"
+          git checkout -b "$BR"
+          echo "name=$BR" >> $GITHUB_OUTPUT
 
-            - name: Ensure CHANGELOG & prepend template
-              if: ${{ steps.decide.outputs.should_release == 'true' }}
-              env:
-                  NEXT: ${{ steps.bump.outputs.next }}
-              run: |
-                  MOD="${{ inputs.module_path }}"
-                  FILE="$MOD/CHANGELOG.md"
-                  DATE="$(date +'%Y-%m-%d')"
+      - name: Ensure CHANGELOG & prepend template
+        if: ${{ steps.decide.outputs.should_release == 'true' }}
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+        run: |
+          MOD="${{ inputs.module_path }}"
+          FILE="$MOD/CHANGELOG.md"
+          DATE="$(date +'%Y-%m-%d')"
 
-                  if [ ! -f "$FILE" ]; then 
-                    {
-                      echo "# Changelog - $MOD"
-                      echo
-                      echo "---"
-                      echo
-                    } > "$FILE"
-                  fi
+          if [ ! -f "$FILE" ]; then 
+            {
+              echo "# Changelog - $MOD"
+              echo
+              echo "---"
+              echo
+            } > "$FILE"
+          fi
 
-                  cat > /tmp/entry.md <<'EOF'
-                  ## [v__NEXT__] - __DATE__
+          cat > /tmp/entry.md <<'EOF'
+          ## [v__NEXT__] - __DATE__
 
-                  ### Added
-                  - (fill)
+          ### Added
+          - (fill)
 
-                  ### Changed
-                  - (fill)
+          ### Changed
+          - (fill)
 
-                  ### Fixed
-                  - (fill)
+          ### Fixed
+          - (fill)
 
-                  ### Removed
-                  - (fill)
-                  EOF
-                  sed -i "s/__NEXT__/${NEXT}/g; s/__DATE__/${DATE}/g" /tmp/entry.md
+          ### Removed
+          - (fill)
+          EOF
+          sed -i "s/__NEXT__/${NEXT}/g; s/__DATE__/${DATE}/g" /tmp/entry.md
 
-                  # If the file contains a line that's exactly '---', insert AFTER that line; else prepend below title
-                  if grep -qx -- '---' "$FILE"; then
-                    awk 'NR==FNR{e[n++]=$0; next}
-                         {print}
-                         !ins && $0=="---"{print ""; for(i=0;i<n;i++) print e[i]; ins=1}
-                         END{if(!ins){print ""; for(i=0;i<n;i++) print e[i]; print ""}}
-                        ' /tmp/entry.md "$FILE" > /tmp/new && mv /tmp/new "$FILE"
-                  else
-                    { head -n1 "$FILE"; echo; cat /tmp/entry.md; tail -n +2 "$FILE"; } > /tmp/new && mv /tmp/new "$FILE"
-                  fi
+          # If the file contains a line that's exactly '---', insert AFTER that line; else prepend below title
+          if grep -qx -- '---' "$FILE"; then
+            awk 'NR==FNR{e[n++]=$0; next}
+                 {print}
+                 !ins && $0=="---"{print ""; for(i=0;i<n;i++) print e[i]; ins=1}
+                 END{if(!ins){print ""; for(i=0;i<n;i++) print e[i]; print ""}}
+                ' /tmp/entry.md "$FILE" > /tmp/new && mv /tmp/new "$FILE"
+          else
+            { head -n1 "$FILE"; echo; cat /tmp/entry.md; tail -n +2 "$FILE"; } > /tmp/new && mv /tmp/new "$FILE"
+          fi
 
-            - name: Commit changes
-              if: ${{ steps.decide.outputs.should_release == 'true' }}
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  git config user.name "github-actions"
-                  git config user.email "github-actions@github.com"
-                  git add .
-                  git diff --cached --quiet || git commit -m "chore(${{ inputs.module_label }}): prepare v${{ steps.bump.outputs.next }} changelog"
+      - name: Commit changes
+        if: ${{ steps.decide.outputs.should_release == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .
+          git diff --cached --quiet || git commit -m "chore(${{ inputs.module_label }}): prepare v${{ steps.bump.outputs.next }} changelog"
 
-            - name: Tag & push (skip on dry-run)
-              if: ${{ steps.decide.outputs.should_release == 'true' && inputs.dry_run == false }}
-              shell: bash
-              env:
-                  GH_PAT: ${{ secrets.GH_PAT }}
-                  NEXT: ${{ steps.bump.outputs.next }}
-              run: |
-                  set -euo pipefail
-                  TAG="${{ inputs.module_path }}/v${NEXT}"
-                  git tag -a "$TAG" -m "release $TAG"
-                  git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}"
-                  git push origin "${{ steps.branch.outputs.name }}"
-                  git push origin "$TAG"
+      - name: Tag & push (skip on dry-run)
+        if: ${{ steps.decide.outputs.should_release == 'true' && inputs.dry_run == false }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT: ${{ steps.bump.outputs.next }}
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.module_path }}/v${NEXT}"
+          git tag -a "$TAG" -m "release $TAG"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
+          git push origin "${{ steps.branch.outputs.name }}"
+          git push origin "$TAG"
 
-            - name: Open PR to dev (skip on dry-run)
-              if: ${{ steps.decide.outputs.should_release == 'true' && inputs.dry_run == false }}
-              env:
-                  GH_TOKEN: ${{ secrets.GH_PAT }}
-              run: |
-                  gh pr create \
-                  --title "chore(${{ inputs.module_label }}): v${{ steps.bump.outputs.next }} changelog" \
-                  --body "Adds the changelog template for the upcoming release." \
-                  --head "${{ steps.branch.outputs.name }}" \
-                  --base "dev"
+      - name: Open PR to dev (skip on dry-run)
+        if: ${{ steps.decide.outputs.should_release == 'true' && inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+          --title "chore(${{ inputs.module_label }}): v${{ steps.bump.outputs.next }} changelog" \
+          --body "Adds the changelog template for the upcoming release." \
+          --head "${{ steps.branch.outputs.name }}" \
+          --base "dev"


### PR DESCRIPTION
## Description

This PR updates the release workflow to use GitHub Actions' built-in `GITHUB_TOKEN` instead of a personal access token when pushing release branches/tags and creating pull requests.

The goal is to have release PRs created through automation rather than under a personal account, making the workflow cleaner for collaboration and review.

## Related Issue(s) and PR(s)

- Related to release workflow automation improvements

## Changes Made

- Replaced `secrets.GH_PAT` with `github.token` in the release workflow
- Updated the tag and push step to authenticate using `GITHUB_TOKEN`
- Updated the PR creation step to use `GITHUB_TOKEN`
- Kept existing workflow permissions for `contents: write` and `pull-requests: write`
- Preserved the existing release branch, tag, and changelog generation flow

## Additional Notes

This change ensures release PRs are created by GitHub Actions instead of a personal account token. Repository settings must allow GitHub Actions to create pull requests for this workflow to function correctly. :contentReference[oaicite:0]{index=0}