### PR TITLE
Agent Dockerfile Version Bump

### DIFF
--- a/gophergate-wg-agent/Dockerfile
+++ b/gophergate-wg-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Description
Bumped the golang image builder version in gophergate-wg-agent from `1.24` to `1.25`.

## Related Issue(s) and PR(s)
- NA

## Changes Made

- Bump golang image builder version from `1.24` to `1.25`

## Additional Notes
NA