### PR TITLE
Added coder dev environment support

### DIFF
--- a/dev-sim/cyro-dev/README.md
+++ b/dev-sim/cyro-dev/README.md
@@ -1,0 +1,174 @@
+# Cyro Dev Services
+
+Shared non-production development services for CyroStack/Coder workspaces.
+
+This folder contains optional Kubernetes manifests for local development from a Coder workspace or any pod inside the cluster.
+
+## Purpose
+
+The `cyro-dev` namespace is used for temporary or non-production services that support development and testing, such as:
+
+- PostgreSQL test database
+- Optional WireGuard test instance
+- Future dev-only services such as Redis, MinIO, or mock APIs
+
+These services are intended for development only and should not be treated as production workloads.
+
+## Folder Structure
+
+```text
+dev-sim/cyro-dev/
+├── namespace.yaml
+├── postgres.yaml
+├── wireguard.yaml
+└── README.md
+```
+
+## Deploy Namespace
+
+Create the shared dev namespace first:
+
+```bash
+kubectl apply -f namespace.yaml
+```
+
+Check:
+
+```bash
+kubectl get ns cyro-dev
+```
+
+## Deploy PostgreSQL
+
+PostgreSQL is the default dev database service.
+
+```bash
+kubectl apply -f postgres.yaml
+```
+
+Check resources:
+
+```bash
+kubectl -n cyro-dev get pods,svc,pvc,secrets
+```
+
+Expected service:
+
+```text
+cyro-dev-postgres.cyro-dev.svc.cluster.local:5432
+```
+
+Default database values:
+
+```text
+Database: gophergate
+Username: gg_admin
+Password: devpassword
+```
+
+Backend connection string:
+
+```bash
+export DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable"
+```
+
+Example backend usage from Coder:
+
+```bash
+cd ~/workspace/<repo>
+export DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable"
+go run .
+```
+
+## Restart PostgreSQL
+
+```bash
+kubectl -n cyro-dev rollout restart deploy/cyro-dev-postgres
+```
+
+View logs:
+
+```bash
+kubectl -n cyro-dev logs deploy/cyro-dev-postgres -f
+```
+
+Connect to PostgreSQL:
+
+```bash
+kubectl -n cyro-dev exec -it deploy/cyro-dev-postgres -- psql -U gg_admin -d gophergate
+```
+
+## Remove PostgreSQL
+
+This removes the Deployment, Service, Secret, and PVC if they are all in `postgres.yaml`.
+
+```bash
+kubectl delete -f postgres.yaml
+```
+
+Warning: deleting the PVC will remove the dev database data.
+
+## Deploy WireGuard
+
+WireGuard is optional and should only be deployed when testing VPN-related behaviour.
+
+It requires privileged permissions and host networking, so it should not be left running unless needed.
+
+```bash
+kubectl apply -f wireguard.yaml
+```
+
+Check resources:
+
+```bash
+kubectl -n cyro-dev get pods,svc,pvc
+```
+
+View logs:
+
+```bash
+kubectl -n cyro-dev logs deploy/cyro-dev-wireguard -f
+```
+
+## Remove WireGuard
+
+```bash
+kubectl delete -f wireguard.yaml
+```
+
+This removes WireGuard while keeping PostgreSQL running.
+
+## Typical Coder Dev Flow
+
+1. Start Coder workspace.
+2. Clone project repo under `~/workspace`.
+3. Deploy dev services:
+
+```bash
+kubectl apply -f dev-services/cyro-dev/namespace.yaml
+kubectl apply -f dev-services/cyro-dev/postgres.yaml
+```
+
+4. Run backend locally inside Coder:
+
+```bash
+export DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable"
+go run .
+```
+
+5. Run frontend locally inside Coder:
+
+```bash
+npm install
+npm run dev -- --host 0.0.0.0
+```
+
+6. Access frontend/backend through Coder workspace ports or Coder apps.
+
+## Notes
+
+- PostgreSQL is safe to keep running for normal dev use.
+- WireGuard is privileged and should be deployed only when needed.
+- This namespace is non-production.
+- Do not store production secrets here.
+- Default credentials are for local/dev testing only.

--- a/dev-sim/cyro-dev/README.md
+++ b/dev-sim/cyro-dev/README.md
@@ -72,13 +72,151 @@ Backend connection string:
 export DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable"
 ```
 
-Example backend usage from Coder:
+## Deploy WireGuard
+
+WireGuard is optional and should only be deployed when testing VPN-related behaviour.
+
+It requires privileged permissions and host networking, so it should not be left running unless needed.
 
 ```bash
-cd ~/workspace/<repo>
-export DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable"
-go run .
+kubectl apply -f wireguard.yaml
 ```
+
+Check resources:
+
+```bash
+kubectl -n cyro-dev get pods,svc,pvc
+```
+
+View logs:
+
+```bash
+kubectl -n cyro-dev logs deploy/cyro-dev-wireguard -f
+```
+
+## Coder Development Flow
+
+For full GopherGate development in Coder, deploy all required dev services first:
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f postgres.yaml
+kubectl apply -f wireguard.yaml
+```
+
+Check that both PostgreSQL and WireGuard are running:
+
+```bash
+kubectl -n cyro-dev get pods,svc,pvc
+```
+
+Expected services:
+
+```text
+cyro-dev-postgres.cyro-dev.svc.cluster.local:5432
+cyro-dev-wireguard.cyro-dev.svc.cluster.local:7443
+```
+
+The PostgreSQL service is used by both the agent and UI. The WireGuard pod provides the `wg0` interface for VPN-related testing.
+
+## Build Agent Binary from Coder
+
+The agent image is only created during release, so for development we manually build the latest local agent binary and copy it into the WireGuard pod.
+
+From the Coder workspace, navigate to the agent repo:
+
+```bash
+cd ~/workspace/GopherGate/gophergate-wg-agent
+```
+
+Build the agent binary for the cluster node architecture:
+
+```bash
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+go build -o /tmp/gophergate-wg-agent ./cmd/gophergate-wg-agent
+```
+
+Get the WireGuard pod name:
+
+```bash
+POD="$(kubectl -n cyro-dev get pod -l app=cyro-dev-wireguard -o jsonpath='{.items[0].metadata.name}')"
+echo "$POD"
+```
+
+Copy the built agent binary into the WireGuard pod:
+
+```bash
+kubectl -n cyro-dev cp /tmp/gophergate-wg-agent "$POD":/tmp/gophergate-wg-agent -c wireguard
+```
+
+Exec into the WireGuard pod:
+
+```bash
+kubectl -n cyro-dev exec -it "$POD" -c wireguard -- bash
+```
+
+Inside the WireGuard pod, verify that `wg0` exists:
+
+```bash
+wg show
+ip link show wg0
+```
+
+Start the agent gRPC server inside the WireGuard pod:
+
+```bash
+chmod +x /tmp/gophergate-wg-agent
+
+DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable" \
+GOPHERGATE_ENV=dev \
+/tmp/gophergate-wg-agent serve
+```
+
+Keep this terminal running while testing the UI.
+
+## Configure UI to Use WireGuard Pod Agent
+
+In another Coder terminal, navigate to the UI repo:
+
+```bash
+cd ~/workspace/GopherGate/gophergate-ui
+```
+
+Update the UI `.env` file to point to the agent gRPC server running inside the WireGuard pod:
+
+```env
+GOPHERGATE_ENV=dev
+HTTP_ADDR=:3000
+GRPC_ADDR=cyro-dev-wireguard.cyro-dev.svc.cluster.local:7443
+GRPC_TLS_ENABLE=false
+WG_IFACE=wg0
+DATABASE_URL=postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable
+```
+
+Then start the UI:
+
+```bash
+go run ./cmd/ui/
+```
+
+Access the UI through the Coder workspace port for `3000`.
+
+## Development Loop After Agent Code Changes
+
+When agent code changes, rebuild and copy the binary again:
+
+```bash
+cd ~/workspace/GopherGate/gophergate-wg-agent
+
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+go build -o /tmp/gophergate-wg-agent ./cmd/gophergate-wg-agent
+
+POD="$(kubectl -n cyro-dev get pod -l app=cyro-dev-wireguard -o jsonpath='{.items[0].metadata.name}')"
+
+kubectl -n cyro-dev cp /tmp/gophergate-wg-agent "$POD":/tmp/gophergate-wg-agent -c wireguard
+```
+
+Then restart the agent process inside the WireGuard pod.
 
 ## Restart PostgreSQL
 
@@ -108,28 +246,6 @@ kubectl delete -f postgres.yaml
 
 Warning: deleting the PVC will remove the dev database data.
 
-## Deploy WireGuard
-
-WireGuard is optional and should only be deployed when testing VPN-related behaviour.
-
-It requires privileged permissions and host networking, so it should not be left running unless needed.
-
-```bash
-kubectl apply -f wireguard.yaml
-```
-
-Check resources:
-
-```bash
-kubectl -n cyro-dev get pods,svc,pvc
-```
-
-View logs:
-
-```bash
-kubectl -n cyro-dev logs deploy/cyro-dev-wireguard -f
-```
-
 ## Remove WireGuard
 
 ```bash
@@ -138,37 +254,23 @@ kubectl delete -f wireguard.yaml
 
 This removes WireGuard while keeping PostgreSQL running.
 
-## Typical Coder Dev Flow
-
-1. Start Coder workspace.
-2. Clone project repo under `~/workspace`.
-3. Deploy dev services:
+## Remove All Dev Services
 
 ```bash
-kubectl apply -f dev-services/cyro-dev/namespace.yaml
-kubectl apply -f dev-services/cyro-dev/postgres.yaml
+kubectl delete -f wireguard.yaml --ignore-not-found
+kubectl delete -f postgres.yaml --ignore-not-found
+kubectl delete -f namespace.yaml --ignore-not-found
 ```
 
-4. Run backend locally inside Coder:
-
-```bash
-export DATABASE_URL="postgres://gg_admin:devpassword@cyro-dev-postgres.cyro-dev.svc.cluster.local:5432/gophergate?sslmode=disable"
-go run .
-```
-
-5. Run frontend locally inside Coder:
-
-```bash
-npm install
-npm run dev -- --host 0.0.0.0
-```
-
-6. Access frontend/backend through Coder workspace ports or Coder apps.
+Warning: removing the namespace deletes all resources inside `cyro-dev`.
 
 ## Notes
 
 - PostgreSQL is safe to keep running for normal dev use.
 - WireGuard is privileged and should be deployed only when needed.
+- The agent must run inside the WireGuard pod to access the `wg0` interface.
+- Running the agent locally in the Coder terminal will not access the WireGuard pod's `wg0`.
+- The agent image is not required for development because the binary is manually built and copied into the WireGuard pod.
 - This namespace is non-production.
 - Do not store production secrets here.
 - Default credentials are for local/dev testing only.

--- a/dev-sim/cyro-dev/namespace.yaml
+++ b/dev-sim/cyro-dev/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cyro-dev
+  labels:
+    app.kubernetes.io/name: cyro-dev
+    app.kubernetes.io/part-of: cyrostack
+    environment: non-prod

--- a/dev-sim/cyro-dev/postgres.yaml
+++ b/dev-sim/cyro-dev/postgres.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cyro-dev-postgres-secret
+  namespace: cyro-dev
+type: Opaque
+stringData:
+  POSTGRES_USER: gg_admin
+  POSTGRES_DB: gophergate
+  POSTGRES_PASSWORD: devpassword
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cyro-dev-postgres-data
+  namespace: cyro-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-csi
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cyro-dev-postgres
+  namespace: cyro-dev
+  labels:
+    app.kubernetes.io/name: cyro-dev-postgres
+    app.kubernetes.io/part-of: cyro-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cyro-dev-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cyro-dev-postgres
+        app.kubernetes.io/part-of: cyro-dev
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: cyro-dev-postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: cyro-dev-postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cyro-dev-postgres-secret
+                  key: POSTGRES_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 15
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: cyro-dev-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cyro-dev-postgres
+  namespace: cyro-dev
+  labels:
+    app.kubernetes.io/name: cyro-dev-postgres
+    app.kubernetes.io/part-of: cyro-dev
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: cyro-dev-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres

--- a/dev-sim/cyro-dev/wireguard.yaml
+++ b/dev-sim/cyro-dev/wireguard.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cyro-dev-wireguard
+  namespace: cyro-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cyro-dev-wireguard
+  template:
+    metadata:
+      labels:
+        app: cyro-dev-wireguard
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: wireguard
+          image: lscr.io/linuxserver/wireguard:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_MODULE
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: Asia/Singapore
+            - name: SERVERURL
+              value: "127.0.0.1"
+            - name: SERVERPORT
+              value: "51820"
+            - name: PEERS
+              value: devpeer
+            - name: PEERDNS
+              value: auto
+            - name: LOG_CONFS
+              value: "true"
+          ports:
+            - name: wireguard
+              containerPort: 51820
+              hostPort: 51820
+              protocol: UDP
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: tun
+              mountPath: /dev/net/tun
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: cyro-dev-wireguard-config
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cyro-dev-wireguard
+  namespace: cyro-dev
+spec:
+  selector:
+    app: cyro-dev-wireguard
+  ports:
+    - name: wireguard
+      port: 51820
+      targetPort: 51820
+      protocol: UDP
+    - name: agent-grpc
+      port: 7443
+      targetPort: 7443
+      protocol: TCP


### PR DESCRIPTION
## Description
Added some yaml files that allows deployment of dev postgres and wireguard to kubernetes cluster in dev namespace. This is to support development environment in the coder environment which is in the kubernetes cluster. 

## Related Issue(s) and PR(s)
- NA

## Changes Made
- Added `cyro-dev` folder that holds new kubernetes yaml files to created dev backend
- Wrote a README for this environment to be reproducible 

## Additional Notes
No testing required.