### PR TITLE
Add automatic IP pool assignment to wg-agent

### DIFF
--- a/gophergate-wg-agent/go.mod
+++ b/gophergate-wg-agent/go.mod
@@ -3,7 +3,7 @@ module github.com/Cyrof/GopherGate/gophergate-wg-agent
 go 1.25.0
 
 require (
-	github.com/Cyrof/GopherGate/gophergate-core v0.6.0
+	github.com/Cyrof/GopherGate/gophergate-core v0.7.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.28.0

--- a/gophergate-wg-agent/go.mod
+++ b/gophergate-wg-agent/go.mod
@@ -3,7 +3,7 @@ module github.com/Cyrof/GopherGate/gophergate-wg-agent
 go 1.25.0
 
 require (
-	github.com/Cyrof/GopherGate/gophergate-core v0.7.0
+	github.com/Cyrof/GopherGate/gophergate-core v0.7.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.28.0

--- a/gophergate-wg-agent/go.sum
+++ b/gophergate-wg-agent/go.sum
@@ -6,6 +6,8 @@ github.com/Cyrof/GopherGate/gophergate-core v0.5.0 h1:CRxBx6D/YhUCu/Xwfp7dBgJn+H
 github.com/Cyrof/GopherGate/gophergate-core v0.5.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
 github.com/Cyrof/GopherGate/gophergate-core v0.6.0 h1:qkjR+J96/zoq1NXBEgpJAQRf41KnapgmtOXJKAHSxuA=
 github.com/Cyrof/GopherGate/gophergate-core v0.6.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
+github.com/Cyrof/GopherGate/gophergate-core v0.7.0 h1:DRcN/A8jRE5igoL/c5IjnbUbBboR1irgGe1QWEknxdw=
+github.com/Cyrof/GopherGate/gophergate-core v0.7.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/gophergate-wg-agent/go.sum
+++ b/gophergate-wg-agent/go.sum
@@ -8,6 +8,8 @@ github.com/Cyrof/GopherGate/gophergate-core v0.6.0 h1:qkjR+J96/zoq1NXBEgpJAQRf41
 github.com/Cyrof/GopherGate/gophergate-core v0.6.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
 github.com/Cyrof/GopherGate/gophergate-core v0.7.0 h1:DRcN/A8jRE5igoL/c5IjnbUbBboR1irgGe1QWEknxdw=
 github.com/Cyrof/GopherGate/gophergate-core v0.7.0/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
+github.com/Cyrof/GopherGate/gophergate-core v0.7.1 h1:dgP24PJ+Ai6U2xPc6XY/m2FQFS2Z6doAz2GNwJvCPWI=
+github.com/Cyrof/GopherGate/gophergate-core v0.7.1/go.mod h1:AHZNUYC6E6x5AFxkyKSOrKuZB3nbrlw8UaxH1Q0lUYw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/gophergate-wg-agent/internal/data/get.go
+++ b/gophergate-wg-agent/internal/data/get.go
@@ -23,7 +23,7 @@ func (r *Repository) GetPublicKeyByName(ctx context.Context, name string) (strin
 
 func (r *Repository) GetByPublicKey(ctx context.Context, pub string) (*Peer, error) {
 	const q = `
-		select id::text, name, public_key, ip_address::text, allowed_ips::text[], endpoint, 
+		select id::text, name, public_key, host(ip_address), allowed_ips::text[], endpoint, 
 			persistent_keepalive, last_handshake, created_at, updated_at
 		from peers
 		where public_key = $1
@@ -83,6 +83,37 @@ func (r *Repository) NamesByPublicKeys(ctx context.Context, pubs []string) (map[
 			return nil, err
 		}
 		out[pk] = name
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) MetadataByPublicKeys(ctx context.Context, pubs []string) (map[string]PeerMetadata, error) {
+	if len(pubs) == 0 {
+		return map[string]PeerMetadata{}, nil
+	}
+	const q = `
+		select public_key, name, host(ip_address)
+		from peers
+		where public_key = any($1::text[])
+	`
+	rows, err := r.db.Query(ctx, q, pubs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]PeerMetadata, len(pubs))
+	for rows.Next() {
+		var publicKey, name string
+		var ipRaw *string
+		if err := rows.Scan(&publicKey, &name, &ipRaw); err != nil {
+			return nil, err
+		}
+		metadata := PeerMetadata{Name: name}
+		if ipRaw != nil {
+			metadata.IPAddress = net.ParseIP(*ipRaw)
+		}
+		out[publicKey] = metadata
 	}
 	return out, rows.Err()
 }

--- a/gophergate-wg-agent/internal/data/insert.go
+++ b/gophergate-wg-agent/internal/data/insert.go
@@ -11,7 +11,7 @@ type rowQuerier interface {
 	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
-func (r *Repository) Insert(ctx context.Context, p Peer) (string, error) { 
+func (r *Repository) Insert(ctx context.Context, p Peer) (string, error) {
 	return insertPeer(ctx, r.db, p)
 }
 

--- a/gophergate-wg-agent/internal/data/insert.go
+++ b/gophergate-wg-agent/internal/data/insert.go
@@ -3,10 +3,20 @@ package data
 import (
 	"context"
 	"fmt"
+
+	"github.com/jackc/pgx/v5"
 )
 
-func (r *Repository) Insert(ctx context.Context, p Peer) (string, error) {
-	const q = `
+type rowQuerier interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func (r *Repository) Insert(ctx context.Context, p Peer) (string, error) { 
+	return insertPeer(ctx, r.db, p)
+}
+
+func insertPeer(ctx context.Context, q rowQuerier, p Peer) (string, error) {
+	const stmt = `
 		insert into peers (name, public_key, ip_address, allowed_ips, endpoint, persistent_keepalive)	
 		values ($1, $2, $3, $4::inet[], $5, $6)
 		returning id::text;
@@ -23,7 +33,7 @@ func (r *Repository) Insert(ctx context.Context, p Peer) (string, error) {
 	}
 
 	var id string
-	if err := r.db.QueryRow(ctx, q,
+	if err := q.QueryRow(ctx, stmt,
 		p.Name,
 		p.PublicKey,
 		ipStr,

--- a/gophergate-wg-agent/internal/data/ip_pool.go
+++ b/gophergate-wg-agent/internal/data/ip_pool.go
@@ -1,0 +1,117 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
+	"github.com/jackc/pgx/v5"
+)
+
+type AutoInsertResult struct {
+	ID           string
+	AssignedIP   netip.Addr
+	AssignedCIDR string
+	AllowedIPs   []net.IPNet
+}
+
+// InsertAutoAssigned serialises allocation for a pool, chooses the lowest free
+// address, and inserts the peer in the same transaction.
+func (r *Repository) InsertAutoAssigned(ctx context.Context, p Peer, pool *ippool.Pool) (AutoInsertResult, error) {
+	if pool == nil {
+		return AutoInsertResult{}, fmt.Errorf("IP pool is not configured")
+	}
+
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return AutoInsertResult{}, fmt.Errorf("begin IP allocation transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	lockName := "gophergate-ip-pool:" + pool.CIDR() + ":" + pool.Start().String() + ":" + pool.End().String()
+	if _, err := tx.Exec(ctx, `select pg_advisory_xact_lock(hashtextextended($1, 0))`, lockName); err != nil {
+		return AutoInsertResult{}, fmt.Errorf("lock IP pool: %w", err)
+	}
+
+	used, err := ipAddressesInRange(ctx, tx, pool.Start(), pool.End())
+	if err != nil {
+		return AutoInsertResult{}, err
+	}
+	assigned, err := pool.NextAvailable(used)
+	if err != nil {
+		return AutoInsertResult{}, err
+	}
+
+	assignedIP := net.IP(assigned.AsSlice())
+	assignedNet := net.IPNet{IP: assignedIP, Mask: net.CIDRMask(32, 32)}
+	p.IPAddress = assignedIP
+	p.AllowedIPs = appendHostCIDR(p.AllowedIPs, assignedNet)
+
+	id, err := insertPeer(ctx, tx, p)
+	if err != nil {
+		return AutoInsertResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return AutoInsertResult{}, fmt.Errorf("commit IP allocation: %w", err)
+	}
+
+	return AutoInsertResult{
+		ID:           id,
+		AssignedIP:   assigned,
+		AssignedCIDR: pool.HostCIDR(assigned),
+		AllowedIPs:   p.AllowedIPs,
+	}, nil
+}
+
+func (r *Repository) IPAddressesInRange(ctx context.Context, start, end netip.Addr) (map[netip.Addr]struct{}, error) {
+	return ipAddressesInRange(ctx, r.db, start, end)
+}
+
+type rowsQuerier interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+func ipAddressesInRange(ctx context.Context, q rowsQuerier, start, end netip.Addr) (map[netip.Addr]struct{}, error) {
+	const stmt = `
+		select host(ip_address)
+		from peers
+		where ip_address is not null
+		  and family(ip_address) = 4
+		  and ip_address >= $1::inet
+		  and ip_address <= $2::inet;
+	`
+	rows, err := q.Query(ctx, stmt, start.String(), end.String())
+	if err != nil {
+		return nil, fmt.Errorf("query allocated IPs: %w", err)
+	}
+	defer rows.Close()
+
+	used := make(map[netip.Addr]struct{})
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("scan allocated IP: %w", err)
+		}
+		addr, err := netip.ParseAddr(raw)
+		if err != nil || !addr.Is4() {
+			continue
+		}
+		used[addr.Unmap()] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read allocated IPs: %w", err)
+	}
+	return used, nil
+}
+
+func appendHostCIDR(existing []net.IPNet, host net.IPNet) []net.IPNet {
+	target := host.String()
+	for _, current := range existing {
+		if current.String() == target {
+			return existing
+		}
+	}
+	return append(existing, host)
+}

--- a/gophergate-wg-agent/internal/data/model.go
+++ b/gophergate-wg-agent/internal/data/model.go
@@ -59,3 +59,8 @@ type PeerTrafficPoint struct {
 	TXBytes    uint64
 	TotalBytes uint64
 }
+
+type PeerMetadata struct {
+	Name      string
+	IPAddress net.IP
+}

--- a/gophergate-wg-agent/internal/grpcserver/server.go
+++ b/gophergate-wg-agent/internal/grpcserver/server.go
@@ -13,6 +13,7 @@ import (
 	gatewayv1 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v1"
 	gatewayv2 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v2"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/service"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -43,13 +44,19 @@ func envDurationOrDefault(key string, def time.Duration) time.Duration {
 }
 
 func Start(logger *zap.SugaredLogger, pool *pgxpool.Pool) error {
-	listenAddr := envOrDefault("GRPC_ADDR", ":7443")
+	addressPool, err := ippool.FromEnv()
+	if err != nil {
+		logger.Errorw("invalid WireGuard IP pool configuration", "err", err)
+		return err
+	}
 
+	listenAddr := envOrDefault("GRPC_ADDR", ":7443")
 	list, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		logger.Errorw("grpc listen failed", "addr", listenAddr, "err", err)
 		return err
 	}
+	defer func() { _ = list.Close() }()
 
 	srv := grpc.NewServer()
 
@@ -60,8 +67,19 @@ func Start(logger *zap.SugaredLogger, pool *pgxpool.Pool) error {
 		logger.Warn("grpc started without db: create via grpc will not persist")
 	}
 
+	if addressPool != nil {
+		logger.Infow("WireGuard IP pool configured",
+			"cidr", addressPool.CIDR(),
+			"start", addressPool.Start().String(),
+			"end", addressPool.End().String(),
+			"capacity", addressPool.Capacity(),
+		)
+	} else {
+		logger.Warn("WireGuard automatic IP assignment is disabled; WG_IP_POOL_CIDR is not set")
+	}
+
 	gatewayv1.RegisterWireGuardServiceServer(srv, NewWireGuardService(repo))
-	gatewayv2.RegisterWireGuardServiceServer(srv, NewWireGuardServiceV2(repo))
+	gatewayv2.RegisterWireGuardServiceServer(srv, NewWireGuardServiceV2(repo, addressPool))
 
 	if repo != nil {
 		iface := envOrDefault("WG_IFACE", "wg0")

--- a/gophergate-wg-agent/internal/grpcserver/wireguard_v2.go
+++ b/gophergate-wg-agent/internal/grpcserver/wireguard_v2.go
@@ -2,6 +2,7 @@ package grpcserver
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	gatewayv2 "github.com/Cyrof/GopherGate/gophergate-core/pkg/gen/gateway/v2"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/service"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/wgsvc"
 )
@@ -17,32 +19,40 @@ import (
 type WireGuardServiceV2 struct {
 	gatewayv2.UnimplementedWireGuardServiceServer
 	repo         *data.Repository
+	ipPool       *ippool.Pool
 	dashboardSvc *service.DashboardService
 	trafficSvc   *service.TrafficService
 }
 
-func NewWireGuardServiceV2(repo *data.Repository) *WireGuardServiceV2 {
+func NewWireGuardServiceV2(repo *data.Repository, ipPool *ippool.Pool) *WireGuardServiceV2 {
 	return &WireGuardServiceV2{
 		repo:         repo,
+		ipPool:       ipPool,
 		dashboardSvc: service.NewDashboardService(repo),
 		trafficSvc:   service.NewTrafficService(repo),
 	}
 }
 
-func mapPeerStatusToProtoV2(p *wgsvc.PeerStatus, name string) *gatewayv2.PeerStatus {
+func mapPeerStatusToProtoV2(p *wgsvc.PeerStatus, metadata data.PeerMetadata) *gatewayv2.PeerStatus {
 	if p == nil {
 		return nil
 	}
 
+	ipAddress := ""
+	if metadata.IPAddress != nil {
+		ipAddress = metadata.IPAddress.String()
+	}
+
 	return &gatewayv2.PeerStatus{
 		PublicKey:  p.PublicKey,
-		Name:       name,
+		Name:       metadata.Name,
 		Endpoint:   p.Endpoint,
 		AllowedIps: p.AllowedIPs,
 		Handshake:  p.Handshake,
 		RxBytes:    p.RxBytes,
 		TxBytes:    p.TxBytes,
 		Keepalive:  p.Keepalive,
+		IpAddress:  ipAddress,
 	}
 }
 
@@ -97,6 +107,7 @@ func mapDashboardToProto(in *service.DashboardResult) *gatewayv2.GetDashboardRes
 			Latency:       p.Latency,
 			State:         p.State,
 			StateReason:   p.StateReason,
+			IpAddress:     p.IPAddress,
 		})
 	}
 
@@ -171,10 +182,96 @@ func (s *WireGuardServiceV2) GetPeerTraffic(
 	return mapPeerTrafficToProto(result), nil
 }
 
+func (s *WireGuardServiceV2) GetPeersPage(
+	ctx context.Context,
+	req *gatewayv2.GetPeersPageRequest,
+) (*gatewayv2.GetPeersPageResponse, error) {
+	if req.GetIface() == "" {
+		return nil, status.Error(codes.InvalidArgument, "iface is required")
+	}
+
+	result, err := s.dashboardSvc.Build(ctx, req.GetIface())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "build peers page: %v", err)
+	}
+
+	response := &gatewayv2.GetPeersPageResponse{
+		Summary: &gatewayv2.PeerDirectorySummary{},
+		Peers:   make([]*gatewayv2.PeerDirectoryItem, 0, len(result.Peers)),
+	}
+
+	for _, peer := range result.Peers {
+		state := peer.State
+		switch state {
+		case "CONNECTED":
+			response.Summary.Connected++
+		case "INTERMITTENT":
+			response.Summary.Intermittent++
+		default:
+			state = "OFFLINE"
+			response.Summary.Offline++
+		}
+
+		response.Peers = append(response.Peers, &gatewayv2.PeerDirectoryItem{
+			PublicKey:     peer.PublicKey,
+			Name:          peer.Name,
+			Endpoint:      peer.Endpoint,
+			AllowedIps:    peer.AllowedIPs,
+			State:         state,
+			StateReason:   peer.StateReason,
+			LastHandshake: peer.LastHandshake,
+			RxBytes:       peer.RXBytes,
+			TxBytes:       peer.TXBytes,
+			Managed:       peer.Managed,
+			IpAddress:     peer.IPAddress,
+		})
+	}
+	response.Summary.Total = int32(len(response.Peers))
+
+	return response, nil
+}
+
+func (s *WireGuardServiceV2) GetIPPool(
+	ctx context.Context,
+	req *gatewayv2.GetIPPoolRequest,
+) (*gatewayv2.GetIPPoolResponse, error) {
+	if req.GetIface() == "" {
+		return nil, status.Error(codes.InvalidArgument, "iface is required")
+	}
+	if s.ipPool == nil {
+		return nil, status.Error(codes.FailedPrecondition, "WireGuard IP pool is not configured")
+	}
+	if s.repo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "WireGuard IP pool requires a database connection")
+	}
+
+	result, err := service.BuildIPPoolStatus(ctx, s.repo, s.ipPool)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get IP pool status: %v", err)
+	}
+
+	return &gatewayv2.GetIPPoolResponse{
+		Pool: &gatewayv2.IPPoolStatus{
+			Cidr:            result.CIDR,
+			RangeStart:      result.RangeStart,
+			RangeEnd:        result.RangeEnd,
+			Capacity:        result.Capacity,
+			Allocated:       result.Allocated,
+			Available:       result.Available,
+			NextAvailableIp: result.NextAvailableIP,
+			ReservedIps:     result.ReservedIPs,
+		},
+	}, nil
+}
+
 func (s *WireGuardServiceV2) CreatePeer(
 	ctx context.Context,
 	req *gatewayv2.CreatePeerRequest,
 ) (*gatewayv2.CreatePeerResponse, error) {
+	if req.GetAutoAssignIp() && s.repo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "automatic IP assignment requires a database connection")
+	}
+
 	svcReq := wgsvc.CreatePeerRequest{
 		Iface:             req.GetIface(),
 		Name:              req.GetName(),
@@ -183,19 +280,32 @@ func (s *WireGuardServiceV2) CreatePeer(
 		Endpoint:          req.GetEndpoint(),
 		KeepaliveSeconds:  int(req.GetKeepaliveSeconds()),
 		ReplaceAllowedIPs: req.GetReplaceAllowedIps(),
+		AutoAssignIP:      req.GetAutoAssignIp(),
+		IPPool:            s.ipPool,
 		Repo:              s.repo,
 	}
 
 	svcResp, err := wgsvc.CreatePeer(ctx, svcReq)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "create peer: %v", err)
+		switch {
+		case errors.Is(err, wgsvc.ErrIPPoolNotConfigured):
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		case wgsvc.IsIPPoolExhausted(err):
+			return nil, status.Error(codes.ResourceExhausted, "no free IP addresses remain in the configured pool")
+		case strings.Contains(strings.ToLower(err.Error()), "required"), strings.Contains(strings.ToLower(err.Error()), "invalid"):
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		default:
+			return nil, status.Errorf(codes.Internal, "create peer: %v", err)
+		}
 	}
 
 	return &gatewayv2.CreatePeerResponse{
-		Iface:         svcReq.Iface,
-		Name:          svcReq.Name,
-		PublicKey:     svcReq.PublicKey,
+		Iface:         svcResp.Iface,
+		Name:          svcResp.Name,
+		PublicKey:     svcResp.PublicKey,
 		ConfigApplied: svcResp.ConfigApplied,
+		AssignedIp:    svcResp.AssignedIP,
+		AssignedCidr:  svcResp.AssignedCIDR,
 	}, nil
 }
 
@@ -247,15 +357,16 @@ func (s *WireGuardServiceV2) GetPeer(
 		return nil, status.Errorf(codes.Internal, "get peer: %v", err)
 	}
 
-	name := ""
+	metadata := data.PeerMetadata{}
 	if s.repo != nil {
 		if dbPeer, dbErr := s.repo.GetByPublicKey(ctx, req.GetPublicKey()); dbErr == nil && dbPeer != nil {
-			name = dbPeer.Name
+			metadata.Name = dbPeer.Name
+			metadata.IPAddress = dbPeer.IPAddress
 		}
 	}
 
 	return &gatewayv2.GetPeerResponse{
-		Peer: mapPeerStatusToProtoV2(peer, name),
+		Peer: mapPeerStatusToProtoV2(peer, metadata),
 	}, nil
 }
 
@@ -272,23 +383,23 @@ func (s *WireGuardServiceV2) ListPeer(
 		return nil, status.Errorf(codes.Internal, "list peers: %v", err)
 	}
 
-	nameMap := map[string]string{}
+	metadataMap := map[string]data.PeerMetadata{}
 	if s.repo != nil {
 		publicKeys := make([]string, 0, len(peers))
 		for _, p := range peers {
 			publicKeys = append(publicKeys, p.PublicKey)
 		}
 
-		names, err := s.repo.NamesByPublicKeys(ctx, publicKeys)
+		metadata, err := s.repo.MetadataByPublicKeys(ctx, publicKeys)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "load peer names: %v", err)
+			return nil, status.Errorf(codes.Internal, "load peer metadata: %v", err)
 		}
-		nameMap = names
+		metadataMap = metadata
 	}
 
 	out := make([]*gatewayv2.PeerStatus, 0, len(peers))
 	for i := range peers {
-		out = append(out, mapPeerStatusToProtoV2(&peers[i], nameMap[peers[i].PublicKey]))
+		out = append(out, mapPeerStatusToProtoV2(&peers[i], metadataMap[peers[i].PublicKey]))
 	}
 
 	return &gatewayv2.ListPeerResponse{

--- a/gophergate-wg-agent/internal/ippool/env.go
+++ b/gophergate-wg-agent/internal/ippool/env.go
@@ -1,0 +1,28 @@
+package ippool
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	EnvCIDR     = "WG_IP_POOL_CIDR"
+	EnvStart    = "WG_IP_POOL_START"
+	EnvEnd      = "WG_IP_POOL_END"
+	EnvReserved = "WG_IP_POOL_RESERVED"
+)
+
+// FromEnv returns nil when no pool CIDR is configured
+func FromEnv() (*Pool, error) {
+	cidr := strings.TrimSpace(os.Getenv(EnvCIDR))
+	if cidr == "" {
+		return nil, nil
+	}
+
+	var reserved []string
+	if raw := strings.TrimSpace(os.Getenv(EnvReserved)); raw != "" {
+		reserved = strings.Split(raw, ",")
+	}
+
+	return New(cidr, os.Getenv(EnvStart), os.Getenv(EnvEnd), reserved)
+}

--- a/gophergate-wg-agent/internal/ippool/env_test.go
+++ b/gophergate-wg-agent/internal/ippool/env_test.go
@@ -1,0 +1,32 @@
+package ippool
+
+import "testing"
+
+func TestFromEnvDisabledWithoutCIDR(t *testing.T) {
+	t.Setenv(EnvCIDR, "")
+	pool, err := FromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool != nil {
+		t.Fatalf("pool=%v want nil", pool)
+	}
+}
+
+func TestFromEnvLoadsRangeAndReservedAddresses(t *testing.T) {
+	t.Setenv(EnvCIDR, "10.20.0.0/24")
+	t.Setenv(EnvStart, "10.20.0.10")
+	t.Setenv(EnvEnd, "10.20.0.20")
+	t.Setenv(EnvReserved, "10.20.0.11, 10.20.0.12")
+
+	pool, err := FromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := pool.Capacity(), uint64(9); got != want {
+		t.Fatalf("capacity=%d want=%d", got, want)
+	}
+	if got, want := len(pool.Reserved()), 2; got != want {
+		t.Fatalf("reserved=%d want %d", got, want)
+	}
+}

--- a/gophergate-wg-agent/internal/ippool/pool.go
+++ b/gophergate-wg-agent/internal/ippool/pool.go
@@ -25,7 +25,7 @@ func New(cidr, start, end string, reserved []string) (*Pool, error) {
 	}
 	prefix = prefix.Masked()
 	if !prefix.Addr().Is4() {
-		return nil, fmt.Errorf("Only IPV4 pools are currently supported")
+		return nil, fmt.Errorf("only IPV4 pools are currently supported")
 	}
 	if prefix.Bits() >= 31 {
 		return nil, fmt.Errorf("pool CIDR %s has no standard usable host range", prefix)

--- a/gophergate-wg-agent/internal/ippool/pool.go
+++ b/gophergate-wg-agent/internal/ippool/pool.go
@@ -18,24 +18,40 @@ type Pool struct {
 	reserved map[netip.Addr]struct{}
 }
 
+// New creates an IPv4 address pool.
+//
+// The start and end addresses are inclusive. When either value is empty, the
+// usable host range of the supplied CIDR is used.
+//
+// Network and broadcast addresses cannot be included in the allocation range.
 func New(cidr, start, end string, reserved []string) (*Pool, error) {
 	prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
 	if err != nil {
 		return nil, fmt.Errorf("parse pool CIDR: %w", err)
 	}
+
 	prefix = prefix.Masked()
+
 	if !prefix.Addr().Is4() {
-		return nil, fmt.Errorf("only IPV4 pools are currently supported")
+		return nil, fmt.Errorf("only IPv4 pools are currently supported")
 	}
+
 	if prefix.Bits() >= 31 {
-		return nil, fmt.Errorf("pool CIDR %s has no standard usable host range", prefix)
+		return nil, fmt.Errorf(
+			"pool CIDR %s has no standard usable host range",
+			prefix,
+		)
 	}
 
 	network := addrToUint32(prefix.Addr())
-	mask := uint32(0xffffffff) << uint32(32-prefix.Bits())
-	broadcast := network | ^mask
+	hostBits := 32 - prefix.Bits()
+
+	// Use uint64 while shifting so a /0 prefix can safely calculate 1 << 32.
+	hostMask := uint32((uint64(1) << uint(hostBits)) - 1)
+	broadcast := network | hostMask
+
 	defaultStart := uint32ToAddr(network + 1)
-	defaultEnd := uint32ToAddr(broadcast + 1)
+	defaultEnd := uint32ToAddr(broadcast - 1)
 
 	startAddr := defaultStart
 	if strings.TrimSpace(start) != "" {
@@ -44,6 +60,7 @@ func New(cidr, start, end string, reserved []string) (*Pool, error) {
 			return nil, err
 		}
 	}
+
 	endAddr := defaultEnd
 	if strings.TrimSpace(end) != "" {
 		endAddr, err = parseIPv4(end, "pool end")
@@ -52,29 +69,54 @@ func New(cidr, start, end string, reserved []string) (*Pool, error) {
 		}
 	}
 
+	startValue := addrToUint32(startAddr)
+	endValue := addrToUint32(endAddr)
+
 	if !prefix.Contains(startAddr) || !prefix.Contains(endAddr) {
-		return nil, fmt.Errorf("pool range %s-%s must be within %s", &startAddr, &endAddr, prefix)
+		return nil, fmt.Errorf(
+			"pool range %s-%s must be within %s",
+			startAddr,
+			endAddr,
+			prefix,
+		)
 	}
-	if addrToUint32(startAddr) < network+1 || addrToUint32(endAddr) > broadcast-1 {
-		return nil, fmt.Errorf("pool range cannot include the network or broadcast address")
+
+	if startValue <= network || endValue >= broadcast {
+		return nil, fmt.Errorf(
+			"pool range cannot include the network or broadcast address",
+		)
 	}
-	if startAddr.Compare(endAddr) > 0 {
-		return nil, fmt.Errorf("pool start %s is after pool end %s", startAddr, endAddr)
+
+	if startValue > endValue {
+		return nil, fmt.Errorf(
+			"pool start %s is after pool end %s",
+			startAddr,
+			endAddr,
+		)
 	}
 
 	reservedSet := make(map[netip.Addr]struct{}, len(reserved))
+
 	for _, raw := range reserved {
 		raw = strings.TrimSpace(raw)
 		if raw == "" {
 			continue
 		}
+
 		addr, err := parseIPv4(raw, "reserved IP")
 		if err != nil {
 			return nil, err
 		}
+
 		if addr.Compare(startAddr) < 0 || addr.Compare(endAddr) > 0 {
-			return nil, fmt.Errorf("reserved IP %s is outside pool range %s-%s", addr, startAddr, endAddr)
+			return nil, fmt.Errorf(
+				"reserved IP %s is outside pool range %s-%s",
+				addr,
+				startAddr,
+				endAddr,
+			)
 		}
+
 		reservedSet[addr] = struct{}{}
 	}
 
@@ -90,46 +132,92 @@ func New(cidr, start, end string, reserved []string) (*Pool, error) {
 	}, nil
 }
 
-func (p *Pool) CIDR() string      { return p.prefix.String() }
-func (p *Pool) Start() netip.Addr { return p.start }
-func (p *Pool) End() netip.Addr   { return p.end }
+// CIDR returns the parent network in CIDR notation.
+func (p *Pool) CIDR() string {
+	return p.prefix.String()
+}
+
+// Start returns the first allocatable address in the configured range.
+func (p *Pool) Start() netip.Addr {
+	return p.start
+}
+
+// End returns the last allocatable address in the configured range.
+func (p *Pool) End() netip.Addr {
+	return p.end
+}
+
+// Capacity returns the number of addresses that may be allocated after
+// excluding reserved addresses.
 func (p *Pool) Capacity() uint64 {
 	return inclusiveSize(p.start, p.end) - uint64(len(p.reserved))
 }
 
+// Reserved returns the configured reserved addresses in ascending order.
 func (p *Pool) Reserved() []netip.Addr {
 	out := make([]netip.Addr, 0, len(p.reserved))
+
 	for addr := range p.reserved {
 		out = append(out, addr)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Compare(out[j]) < 0 })
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Compare(out[j]) < 0
+	})
+
 	return out
 }
 
+// Contains reports whether the address is inside the configured allocation
+// range. Reserved addresses are still considered part of the range.
 func (p *Pool) Contains(addr netip.Addr) bool {
-	return addr.Is4() && addr.Compare(p.start) >= 0 && addr.Compare(p.end) <= 0
+	if !addr.Is4() {
+		return false
+	}
+
+	addr = addr.Unmap()
+
+	return addr.Compare(p.start) >= 0 &&
+		addr.Compare(p.end) <= 0
 }
 
+// IsReserved reports whether the address has been explicitly reserved.
 func (p *Pool) IsReserved(addr netip.Addr) bool {
-	_, ok := p.reserved[addr]
+	if !addr.Is4() {
+		return false
+	}
+
+	_, ok := p.reserved[addr.Unmap()]
 	return ok
 }
 
+// HostCIDR returns the address as an IPv4 host route.
 func (p *Pool) HostCIDR(addr netip.Addr) string {
-	return netip.PrefixFrom(addr, 32).String()
+	return netip.PrefixFrom(addr.Unmap(), 32).String()
 }
 
-func (p *Pool) NextAvailable(used map[netip.Addr]struct{}) (netip.Addr, error) {
-	for n, last := addrToUint32(p.start), addrToUint32(p.end); n <= last; n++ {
-		addr := uint32ToAddr(n)
+// NextAvailable returns the lowest non-reserved address that does not exist in
+// the supplied used-address set.
+func (p *Pool) NextAvailable(
+	used map[netip.Addr]struct{},
+) (netip.Addr, error) {
+	first := addrToUint32(p.start)
+	last := addrToUint32(p.end)
+
+	for current := first; current <= last; current++ {
+		addr := uint32ToAddr(current)
+
 		if p.IsReserved(addr) {
 			continue
 		}
+
 		if _, exists := used[addr]; exists {
 			continue
 		}
+
 		return addr, nil
 	}
+
 	return netip.Addr{}, ErrExhausted
 }
 
@@ -138,9 +226,11 @@ func parseIPv4(raw, field string) (netip.Addr, error) {
 	if err != nil {
 		return netip.Addr{}, fmt.Errorf("parse %s: %w", field, err)
 	}
+
 	if !addr.Is4() {
 		return netip.Addr{}, fmt.Errorf("%s must be an IPv4 address", field)
 	}
+
 	return addr.Unmap(), nil
 }
 
@@ -149,10 +239,19 @@ func inclusiveSize(start, end netip.Addr) uint64 {
 }
 
 func addrToUint32(addr netip.Addr) uint32 {
-	b := addr.As16()
-	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+	bytes := addr.Unmap().As4()
+
+	return uint32(bytes[0])<<24 |
+		uint32(bytes[1])<<16 |
+		uint32(bytes[2])<<8 |
+		uint32(bytes[3])
 }
 
-func uint32ToAddr(v uint32) netip.Addr {
-	return netip.AddrFrom4([4]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+func uint32ToAddr(value uint32) netip.Addr {
+	return netip.AddrFrom4([4]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
 }

--- a/gophergate-wg-agent/internal/ippool/pool.go
+++ b/gophergate-wg-agent/internal/ippool/pool.go
@@ -1,0 +1,158 @@
+package ippool
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+var ErrExhausted = errors.New("IP pool exhausted")
+
+// Pool represents an inclusive IPv4 allocation range within a CIDR.
+type Pool struct {
+	prefix   netip.Prefix
+	start    netip.Addr
+	end      netip.Addr
+	reserved map[netip.Addr]struct{}
+}
+
+func New(cidr, start, end string, reserved []string) (*Pool, error) {
+	prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+	if err != nil {
+		return nil, fmt.Errorf("parse pool CIDR: %w", err)
+	}
+	prefix = prefix.Masked()
+	if !prefix.Addr().Is4() {
+		return nil, fmt.Errorf("Only IPV4 pools are currently supported")
+	}
+	if prefix.Bits() >= 31 {
+		return nil, fmt.Errorf("pool CIDR %s has no standard usable host range", prefix)
+	}
+
+	network := addrToUint32(prefix.Addr())
+	mask := uint32(0xffffffff) << uint32(32-prefix.Bits())
+	broadcast := network | ^mask
+	defaultStart := uint32ToAddr(network + 1)
+	defaultEnd := uint32ToAddr(broadcast + 1)
+
+	startAddr := defaultStart
+	if strings.TrimSpace(start) != "" {
+		startAddr, err = parseIPv4(start, "pool start")
+		if err != nil {
+			return nil, err
+		}
+	}
+	endAddr := defaultEnd
+	if strings.TrimSpace(end) != "" {
+		endAddr, err = parseIPv4(end, "pool end")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !prefix.Contains(startAddr) || !prefix.Contains(endAddr) {
+		return nil, fmt.Errorf("pool range %s-%s must be within %s", &startAddr, &endAddr, prefix)
+	}
+	if addrToUint32(startAddr) < network+1 || addrToUint32(endAddr) > broadcast-1 {
+		return nil, fmt.Errorf("pool range cannot include the network or broadcast address")
+	}
+	if startAddr.Compare(endAddr) > 0 {
+		return nil, fmt.Errorf("pool start %s is after pool end %s", startAddr, endAddr)
+	}
+
+	reservedSet := make(map[netip.Addr]struct{}, len(reserved))
+	for _, raw := range reserved {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		addr, err := parseIPv4(raw, "reserved IP")
+		if err != nil {
+			return nil, err
+		}
+		if addr.Compare(startAddr) < 0 || addr.Compare(endAddr) > 0 {
+			return nil, fmt.Errorf("reserved IP %s is outside pool range %s-%s", addr, startAddr, endAddr)
+		}
+		reservedSet[addr] = struct{}{}
+	}
+
+	if uint64(len(reservedSet)) >= inclusiveSize(startAddr, endAddr) {
+		return nil, fmt.Errorf("all addresses in the pool are reserved")
+	}
+
+	return &Pool{
+		prefix:   prefix,
+		start:    startAddr,
+		end:      endAddr,
+		reserved: reservedSet,
+	}, nil
+}
+
+func (p *Pool) CIDR() string      { return p.prefix.String() }
+func (p *Pool) Start() netip.Addr { return p.start }
+func (p *Pool) End() netip.Addr   { return p.end }
+func (p *Pool) Capacity() uint64 {
+	return inclusiveSize(p.start, p.end) - uint64(len(p.reserved))
+}
+
+func (p *Pool) Reserved() []netip.Addr {
+	out := make([]netip.Addr, 0, len(p.reserved))
+	for addr := range p.reserved {
+		out = append(out, addr)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Compare(out[j]) < 0 })
+	return out
+}
+
+func (p *Pool) Contains(addr netip.Addr) bool {
+	return addr.Is4() && addr.Compare(p.start) >= 0 && addr.Compare(p.end) <= 0
+}
+
+func (p *Pool) IsReserved(addr netip.Addr) bool {
+	_, ok := p.reserved[addr]
+	return ok
+}
+
+func (p *Pool) HostCIDR(addr netip.Addr) string {
+	return netip.PrefixFrom(addr, 32).String()
+}
+
+func (p *Pool) NextAvailable(used map[netip.Addr]struct{}) (netip.Addr, error) {
+	for n, last := addrToUint32(p.start), addrToUint32(p.end); n <= last; n++ {
+		addr := uint32ToAddr(n)
+		if p.IsReserved(addr) {
+			continue
+		}
+		if _, exists := used[addr]; exists {
+			continue
+		}
+		return addr, nil
+	}
+	return netip.Addr{}, ErrExhausted
+}
+
+func parseIPv4(raw, field string) (netip.Addr, error) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(raw))
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("parse %s: %w", field, err)
+	}
+	if !addr.Is4() {
+		return netip.Addr{}, fmt.Errorf("%s must be an IPv4 address", field)
+	}
+	return addr.Unmap(), nil
+}
+
+func inclusiveSize(start, end netip.Addr) uint64 {
+	return uint64(addrToUint32(end)-addrToUint32(start)) + 1
+}
+
+func addrToUint32(addr netip.Addr) uint32 {
+	b := addr.As16()
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}
+
+func uint32ToAddr(v uint32) netip.Addr {
+	return netip.AddrFrom4([4]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+}

--- a/gophergate-wg-agent/internal/ippool/pool_test.go
+++ b/gophergate-wg-agent/internal/ippool/pool_test.go
@@ -1,0 +1,91 @@
+package ippool
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+)
+
+func TestPoolNextAvailable(t *testing.T) {
+	p, err := New("10.13.13.0/24", "10.13.13.2", "10.13.13.5", []string{"10.13.13.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := p.Capacity(), uint64(3); got != want {
+		t.Fatalf("capacity=%d want=%d", got, want)
+	}
+
+	used := map[netip.Addr]struct{}{
+		netip.MustParseAddr("10.13.13.2"): {},
+		netip.MustParseAddr("10.13.13.4"): {},
+	}
+	got, err := p.NextAvailable(used)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := netip.MustParseAddr("10.13.13.5"); got != want {
+		t.Fatalf("next=%s want=%s", got, want)
+	}
+}
+
+func TestPoolExhausted(t *testing.T) {
+	p, err := New("10.0.0.0/30", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	used := map[netip.Addr]struct{}{
+		netip.MustParseAddr("10.0.0.1"): {},
+		netip.MustParseAddr("10.0.0.2"): {},
+	}
+	_, err = p.NextAvailable(used)
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("err=%v want ErrExhausted", err)
+	}
+}
+
+func TestPoolRejectsOutOfRangeReservedIP(t *testing.T) {
+	_, err := New("10.0.0.0/24", "10.0.0.10", "10.0.0.20", []string{"10.0.0.1"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPoolUsesDefaultHostRange(t *testing.T) {
+	p, err := New("192.0.2.0/30", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := p.Start(), netip.MustParseAddr("192.0.2.1"); got != want {
+		t.Fatalf("start=%s want=%s", got, want)
+	}
+	if got, want := p.End(), netip.MustParseAddr("192.0.2.2"); got != want {
+		t.Fatalf("end=%s want=%s", got, want)
+	}
+	if got, want := p.Capacity(), uint64(2); got != want {
+		t.Fatalf("capacity=%d want=%d", got, want)
+	}
+}
+
+func TestPoolRejectsNetworkAndBroadcastAddresses(t *testing.T) {
+	tests := []struct {
+		name  string
+		start string
+		end   string
+	}{
+		{name: "network", start: "10.0.0.0", end: "10.0.0.10"},
+		{name: "broadcast", start: "10.0.0.10", end: "10.0.0.255"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := New("10.0.0.0/24", tt.start, tt.end, nil); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestPoolRejectsIPv6(t *testing.T) {
+	if _, err := New("fd00::/64", "", "", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/gophergate-wg-agent/internal/service/dashboard.go
+++ b/gophergate-wg-agent/internal/service/dashboard.go
@@ -51,6 +51,8 @@ type DashboardPeer struct {
 	Latency       string
 	State         string
 	StateReason   string
+	IPAddress     string
+	Managed       bool
 }
 
 type DashboardAlert struct {
@@ -81,22 +83,28 @@ func (s *DashboardService) Build(ctx context.Context, iface string) (*DashboardR
 		publicKeys = append(publicKeys, p.PublicKey)
 	}
 
-	nameMap := map[string]string{}
+	metadataMap := map[string]data.PeerMetadata{}
 	if s.repo != nil {
-		names, err := s.repo.NamesByPublicKeys(ctx, publicKeys)
+		metadata, err := s.repo.MetadataByPublicKeys(ctx, publicKeys)
 		if err != nil {
-			return nil, fmt.Errorf("load peer names: %w", err)
+			return nil, fmt.Errorf("load peer metadata: %w", err)
 		}
-		nameMap = names
+		metadataMap = metadata
 	}
 
 	peers := make([]DashboardPeer, 0, len(runtimePeers))
 	for _, rp := range runtimePeers {
 		state, reason := derivePeerState(rp.Handshake)
 
-		name := nameMap[rp.PublicKey]
+		metadata, managed := metadataMap[rp.PublicKey]
+		name := metadata.Name
 		if name == "" {
 			name = shortenKey(rp.PublicKey)
+		}
+
+		ipAddress := ""
+		if metadata.IPAddress != nil {
+			ipAddress = metadata.IPAddress.String()
 		}
 
 		peers = append(peers, DashboardPeer{
@@ -110,6 +118,8 @@ func (s *DashboardService) Build(ctx context.Context, iface string) (*DashboardR
 			Latency:       "-",
 			State:         state,
 			StateReason:   reason,
+			IPAddress:     ipAddress,
+			Managed:       managed,
 		})
 	}
 

--- a/gophergate-wg-agent/internal/service/ip_pool.go
+++ b/gophergate-wg-agent/internal/service/ip_pool.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
+)
+
+type IPPoolStatus struct {
+	CIDR            string
+	RangeStart      string
+	RangeEnd        string
+	Capacity        uint64
+	Allocated       uint64
+	Available       uint64
+	NextAvailableIP string
+	ReservedIPs     []string
+}
+
+func BuildIPPoolStatus(ctx context.Context, repo *data.Repository, pool *ippool.Pool) (*IPPoolStatus, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("IP pool is not configured")
+	}
+	if repo == nil {
+		return nil, fmt.Errorf("database repository is required for IP pool status")
+	}
+
+	used, err := repo.IPAddressesInRange(ctx, pool.Start(), pool.End())
+	if err != nil {
+		return nil, err
+	}
+
+	var allocated uint64
+	for addr := range used {
+		if pool.Contains(addr) && !pool.IsReserved(addr) {
+			allocated++
+		}
+	}
+	capacity := pool.Capacity()
+	if allocated > capacity {
+		allocated = capacity
+	}
+
+	next := ""
+	if addr, err := pool.NextAvailable(used); err == nil {
+		next = addr.String()
+	} else if !wgPoolExhausted(err) {
+		return nil, err
+	}
+
+	reserved := pool.Reserved()
+	reservedStrings := make([]string, 0, len(reserved))
+	for _, addr := range reserved {
+		reservedStrings = append(reservedStrings, addr.String())
+	}
+
+	return &IPPoolStatus{
+		CIDR:            pool.CIDR(),
+		RangeStart:      pool.Start().String(),
+		RangeEnd:        pool.End().String(),
+		Capacity:        capacity,
+		Allocated:       allocated,
+		Available:       capacity - allocated,
+		NextAvailableIP: next,
+		ReservedIPs:     reservedStrings,
+	}, nil
+}
+
+func wgPoolExhausted(err error) bool {
+	return errors.Is(err, ippool.ErrExhausted)
+}

--- a/gophergate-wg-agent/internal/wgsvc/create.go
+++ b/gophergate-wg-agent/internal/wgsvc/create.go
@@ -2,15 +2,19 @@ package wgsvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
+
+var ErrIPPoolNotConfigured = errors.New("automatic IP assignment requires a configured IP pool")
 
 func CreatePeer(ctx context.Context, req CreatePeerRequest) (CreatePeerResponse, error) {
 	// validate input
@@ -20,16 +24,17 @@ func CreatePeer(ctx context.Context, req CreatePeerRequest) (CreatePeerResponse,
 	if req.PublicKey == "" {
 		return CreatePeerResponse{}, fmt.Errorf("public key is required")
 	}
-	if len(req.AllowedCIDRs) == 0 {
-		return CreatePeerResponse{}, fmt.Errorf("at least one allowed CIDR is required")
+	if !req.AutoAssignIP && len(req.AllowedCIDRs) == 0 {
+		return CreatePeerResponse{}, fmt.Errorf("at least one allowed CIDR is required when automatic IP assignment is disabled")
 	}
-
-	// open wgctrl client
-	cli, err := wgctrl.New()
-	if err != nil {
-		return CreatePeerResponse{}, fmt.Errorf("wgctrl new: %w", err)
+	if req.AutoAssignIP {
+		if req.IPPool == nil {
+			return CreatePeerResponse{}, ErrIPPoolNotConfigured
+		}
+		if req.Repo == nil {
+			return CreatePeerResponse{}, fmt.Errorf("automatic IP assignment requires a database repository")
+		}
 	}
-	defer func() { _ = cli.Close() }()
 
 	// parse inputs into wgtypes
 	pub, err := wgtypes.ParseKey(req.PublicKey)
@@ -37,69 +42,77 @@ func CreatePeer(ctx context.Context, req CreatePeerRequest) (CreatePeerResponse,
 		return CreatePeerResponse{}, fmt.Errorf("parse public key: %w", err)
 	}
 
-	var allowed []net.IPNet
-	for _, cidr := range req.AllowedCIDRs {
-		_, ipn, err := net.ParseCIDR(strings.TrimSpace(cidr))
+	allowed, err := parseAllowedCIDRs(req.AllowedCIDRs)
+	if err != nil {
+		return CreatePeerResponse{}, nil
+	}
+
+	ep, err := parseEndpoint(req.Endpoint)
+	if err != nil {
+		return CreatePeerResponse{}, err
+	}
+
+	ka := keepaliveDuration(req.KeepaliveSeconds)
+
+	peerRecord := data.Peer{
+		Name:                req.Name,
+		PublicKey:           pub.String(),
+		AllowedIPs:          allowed,
+		Endpoint:            optionalString(req.Endpoint),
+		PersistentKeepalive: optionalI16(req.KeepaliveSeconds),
+	}
+
+	var (
+		id           string
+		assignedIP   string
+		assignedCIDR string
+	)
+
+	if req.AutoAssignIP {
+		allocation, err := req.Repo.InsertAutoAssigned(ctx, peerRecord, req.IPPool)
 		if err != nil {
-			return CreatePeerResponse{}, fmt.Errorf("invalid allowed CIDR %q: %w", cidr, err)
+			return CreatePeerResponse{}, fmt.Errorf("allocate peer IP: %w", err)
 		}
-		allowed = append(allowed, *ipn)
-	}
+		id = allocation.ID
+		assignedIP = allocation.AssignedIP.String()
+		assignedCIDR = allocation.AssignedCIDR
+		allowed = allocation.AllowedIPs
 
-	var ep *net.UDPAddr
-	if req.Endpoint != "" {
-		addr, err := net.ResolveUDPAddr("udp", req.Endpoint)
-		if err != nil {
-			return CreatePeerResponse{}, fmt.Errorf("invalid endpoint %q: %w", req.Endpoint, err)
-		}
-		ep = addr
-	}
-
-	var ka *time.Duration
-	if req.KeepaliveSeconds > 0 {
-		d := time.Duration(req.KeepaliveSeconds) * time.Second
-		ka = &d
-	}
-
-	// build the peer and apply to device
-	pc := wgtypes.PeerConfig{
-		PublicKey:                   pub,
-		ReplaceAllowedIPs:           req.ReplaceAllowedIPs,
-		AllowedIPs:                  allowed,
-		Endpoint:                    ep,
-		PersistentKeepaliveInterval: ka,
-	}
-	cfg := wgtypes.Config{Peers: []wgtypes.PeerConfig{pc}}
-
-	// atomic apply, kernel updates the device with this peer configuration
-	if err := cli.ConfigureDevice(req.Iface, cfg); err != nil {
-		return CreatePeerResponse{}, fmt.Errorf("configure device: %w", err)
-	}
-
-	// persist to db
-	var id string
-	if req.Repo != nil {
-		primaryIP := pickPrimaryIP(req.AllowedCIDRs)
-
-		var err error
-		id, err = req.Repo.Insert(ctx, data.Peer{
-			Name:                req.Name,
-			PublicKey:           pub.String(),
-			IPAddress:           primaryIP,
-			Endpoint:            optionalString(req.Endpoint),
-			PersistentKeepalive: optionalI16(req.KeepaliveSeconds),
-		})
-		if err != nil {
-			// roll back to avoid drift
-			rollbackErr := cli.ConfigureDevice(req.Iface, wgtypes.Config{
-				Peers: []wgtypes.PeerConfig{
-					{PublicKey: pub, Remove: true},
-				},
-			})
-			if rollbackErr != nil {
-				fmt.Printf("rollback failed for peer %s on %s: %v\n", pub.String(), req.Iface, rollbackErr)
+		if err := configurePeer(req, pub, allowed, ep, ka); err != nil {
+			cleanupErr := cleanupAutoAllocation(ctx, req.Repo, pub.String())
+			if cleanupErr != nil {
+				return CreatePeerResponse{}, fmt.Errorf("%w; database cleanup also failed: %v", err, cleanupErr)
 			}
-			return CreatePeerResponse{}, fmt.Errorf("insert peer: %w", err)
+			return CreatePeerResponse{}, err
+		}
+	} else {
+		primaryIP := pickPrimaryIP(req.AllowedCIDRs)
+		if primaryIP == nil {
+			return CreatePeerResponse{}, fmt.Errorf("manual assignment requires a host CIDR such as /32 or /128")
+		}
+		peerRecord.IPAddress = primaryIP
+
+		if err := configurePeer(req, pub, allowed, ep, ka); err != nil {
+			return CreatePeerResponse{}, err
+		}
+
+		if req.Repo != nil {
+			id, err = req.Repo.Insert(ctx, peerRecord)
+			if err != nil {
+				rollbackErr := removePeer(req.Iface, pub)
+				if rollbackErr != nil {
+					return CreatePeerResponse{}, fmt.Errorf("insert peer: %w; WireGuard rollback also failed: %v", err, rollbackErr)
+				}
+				return CreatePeerResponse{}, fmt.Errorf("insert peer: %w", err)
+			}
+		}
+		assignedIP = primaryIP.String()
+		for _, cidr := range req.AllowedCIDRs {
+			ip, ipNet, parseErr := net.ParseCIDR(strings.TrimSpace(cidr))
+			if parseErr == nil && ip.Equal(primaryIP) {
+				assignedCIDR = (&net.IPNet{IP: ip, Mask: ipNet.Mask}).String()
+				break
+			}
 		}
 	}
 
@@ -109,5 +122,85 @@ func CreatePeer(ctx context.Context, req CreatePeerRequest) (CreatePeerResponse,
 		PublicKey:     pub.String(),
 		ConfigApplied: true,
 		ID:            id,
+		AssignedIP:    assignedIP,
+		AssignedCIDR:  assignedCIDR,
 	}, nil
+}
+
+func configurePeer(req CreatePeerRequest, pub wgtypes.Key, allowed []net.IPNet, ep *net.UDPAddr, ka *time.Duration) error {
+	cli, err := wgctrl.New()
+	if err != nil {
+		return fmt.Errorf("wgctrl new: %w", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	cfg := wgtypes.Config{Peers: []wgtypes.PeerConfig{{
+		PublicKey:                   pub,
+		ReplaceAllowedIPs:           req.ReplaceAllowedIPs,
+		AllowedIPs:                  allowed,
+		Endpoint:                    ep,
+		PersistentKeepaliveInterval: ka,
+	}}}
+	if err := cli.ConfigureDevice(req.Iface, cfg); err != nil {
+		return fmt.Errorf("configure device: %w", err)
+	}
+	return nil
+}
+
+func removePeer(iface string, pub wgtypes.Key) error {
+	cli, err := wgctrl.New()
+	if err != nil {
+		return fmt.Errorf("wgctrl new: %w", err)
+	}
+	defer func() { _ = cli.Close() }()
+	return cli.ConfigureDevice(iface, wgtypes.Config{Peers: []wgtypes.PeerConfig{{PublicKey: pub, Remove: true}}})
+}
+
+func cleanupAutoAllocation(ctx context.Context, repo *data.Repository, publicKey string) error {
+	if repo == nil {
+		return nil
+	}
+	_, err := repo.DeleteByPublicKey(ctx, publicKey)
+	return err
+}
+
+func parseAllowedCIDRs(cidrs []string) ([]net.IPNet, error) {
+	allowed := make([]net.IPNet, 0, len(cidrs))
+	seen := make(map[string]struct{}, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipn, err := net.ParseCIDR(strings.TrimSpace(cidr))
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowed CIDR %q: %w", cidr, err)
+		}
+		canonical := ipn.String()
+		if _, exists := seen[canonical]; exists {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		allowed = append(allowed, *ipn)
+	}
+	return allowed, nil
+}
+
+func parseEndpoint(endpoint string) (*net.UDPAddr, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return nil, nil
+	}
+	addr, err := net.ResolveUDPAddr("udp", endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+	}
+	return addr, nil
+}
+
+func keepaliveDuration(seconds int) *time.Duration {
+	if seconds <= 0 {
+		return nil
+	}
+	d := time.Duration(seconds) * time.Second
+	return &d
+}
+
+func IsIPPoolExhausted(err error) bool {
+	return errors.Is(err, ippool.ErrExhausted)
 }

--- a/gophergate-wg-agent/internal/wgsvc/model.go
+++ b/gophergate-wg-agent/internal/wgsvc/model.go
@@ -1,6 +1,9 @@
 package wgsvc
 
-import "github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+import (
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
+)
 
 type DeviceStatus struct {
 	Interface    string       `json:"interface"`
@@ -28,6 +31,8 @@ type CreatePeerRequest struct {
 	Endpoint          string
 	KeepaliveSeconds  int
 	ReplaceAllowedIPs bool
+	AutoAssignIP      bool
+	IPPool            *ippool.Pool
 	Repo              *data.Repository
 }
 
@@ -37,6 +42,8 @@ type CreatePeerResponse struct {
 	PublicKey     string `json:"public_key"`
 	ConfigApplied bool   `json:"config_applied"`
 	ID            string
+	AssignedIP    string `json:"assigned_ip,omitempty"`
+	AssignedCIDR  string `json:"assigned_cidr,omitempty"`
 }
 
 type UpdatePeerRequest struct {

--- a/gophergate-wg-agent/internal/wgsvc/utils.go
+++ b/gophergate-wg-agent/internal/wgsvc/utils.go
@@ -1,10 +1,13 @@
 package wgsvc
 
-import "net"
+import (
+	"net"
+	"strings"
+)
 
 func pickPrimaryIP(cidrs []string) net.IP {
 	for _, c := range cidrs {
-		ip, ipNet, err := net.ParseCIDR(c)
+		ip, ipNet, err := net.ParseCIDR(strings.TrimSpace(c))
 		if err != nil {
 			continue
 		}

--- a/gophergate-wg-agent/pkg/cobraCLI/create.go
+++ b/gophergate-wg-agent/pkg/cobraCLI/create.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/data"
+	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/ippool"
 	"github.com/Cyrof/GopherGate/gophergate-wg-agent/internal/wgsvc"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ var (
 	createEndpoint   string
 	createKeepalive  int
 	createReplaceIPs bool
+	createAutoIP     bool
 )
 
 var createCmd = &cobra.Command{
@@ -29,19 +31,25 @@ var createCmd = &cobra.Command{
 	Short:   "Create a new WireGuard peer and persist it to the database",
 	Long: `The create command provisions a new WireGuard peer, applies the configuration to the
 WireGuard interface, and persists the peer record into the database. Each peer must
-have a unique name, public key, and one or more allowed IPs (CIDRs).`,
+have a unique public key. The peer address can be supplied manually or allocated from the configured IP pool.`,
 	Example: `
 	# Create a new peer with basic settings 
 	gophergate-wg-agent create --name alice --pubkey <base64> --allowed 10.0.0.2/32 --keepalive 25
 
-	# Create another peer on interface wg1 with multiple allowed 	
-	gophergate-wg-agent create -i wg1 -n bob -p <base64> -a 10.0.0.3/32 -a 10.0.1.0/32 -k 30
+	# Create a peer with an automatically assigned address
+	gophergate-wg-agent create --name bob --pubkey <base64> --auto-ip --keepalive 25
+
+	# Auto-assign the peer address and add another routed network
+	gophergate-wg-agent create -i wg1 -n carol -p <base64> --auto-ip -a 10.0.1.0/24 -k 30
   	`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if createKeepalive < 0 {
 			return errors.New("--keepalive must be >= 0")
 		}
-		// validate allowed CIDRs
+		if !createAutoIP && len(createAllowed) == 0 {
+			return errors.New("--allowed is required unless --auto-ip is enabled")
+		}
+		// validate any extra allowed CIDRs
 		for _, cidr := range createAllowed {
 			if _, _, err := net.ParseCIDR(cidr); err != nil {
 				return fmt.Errorf("invalid --allowed CIDR %q: %w", cidr, err)
@@ -58,6 +66,10 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 		}
 
 		repo := data.NewRepository(DB)
+		addressPool, err := ippool.FromEnv()
+		if err != nil {
+			return fmt.Errorf("load IP pool configuration: %w", err)
+		}
 
 		req := wgsvc.CreatePeerRequest{
 			Iface:             createIface,
@@ -67,6 +79,8 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 			Endpoint:          createEndpoint,
 			KeepaliveSeconds:  createKeepalive,
 			ReplaceAllowedIPs: createReplaceIPs,
+			AutoAssignIP:      createAutoIP,
+			IPPool:            addressPool,
 			Repo:              repo,
 		}
 
@@ -85,10 +99,8 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 			return err
 		}
 
-		primaryIP := pickPrimaryIP(createAllowed)
-
-		outf(cmd, "Peer created on %s\n ID: %s\n Name: %s\n PublicKey: %s\n PrimaryIP: %s\n ConfigApplied: %t\n",
-			resp.Iface, resp.ID, resp.Name, resp.PublicKey, primaryIP, resp.ConfigApplied,
+		outf(cmd, "Peer created on %s\n ID: %s\n Name: %s\n PublicKey: %s\n AssignedIP: %s\n AssignedCIDR: %s\n ConfigApplied: %t\n",
+			resp.Iface, resp.ID, resp.Name, resp.PublicKey, resp.AssignedIP, resp.AssignedCIDR, resp.ConfigApplied,
 		)
 
 		Log.Infow("peerCreated",
@@ -97,7 +109,8 @@ have a unique name, public key, and one or more allowed IPs (CIDRs).`,
 			"iface", resp.Iface,
 			"pubKey", resp.PublicKey,
 			"configApplied", resp.ConfigApplied,
-			"ip", primaryIP,
+			"ip", resp.AssignedIP,
+			"autoAssigned", createAutoIP,
 		)
 
 		Log.Debugw("peer create request detail",
@@ -117,16 +130,13 @@ func init() {
 	createCmd.Flags().StringVarP(&createIface, "iface", "i", "wg0", "WireGuard interface name")
 	createCmd.Flags().StringVarP(&createName, "name", "n", "", "Friendly name for this peer (optional)")
 	createCmd.Flags().StringVarP(&createPubKey, "pubkey", "p", "", "Peer public key (base64, required)")
-	createCmd.Flags().StringSliceVarP(&createAllowed, "allowed", "a", nil, "Allowed IPs (CIDR). Repeatable (required)")
+	createCmd.Flags().StringSliceVarP(&createAllowed, "allowed", "a", nil, "Additional allowed IPs/routes (CIDR). Required unless --auto-ip is enabled")
 	createCmd.Flags().IntVarP(&createKeepalive, "keepalive", "k", 0, "Persistent keepalive in seconds (0 = disabled)")
 	createCmd.Flags().BoolVarP(&createReplaceIPs, "replace-ips", "r", true, "Replace existing AllowedIPs for this peer")
+	createCmd.Flags().BoolVar(&createAutoIP, "auto-ip", false, "Automatically assign the lowest free IP from the configured pool")
 
 	if err := createCmd.MarkFlagRequired("pubkey"); err != nil {
 		Log.Errorw("Failed to mark flag as required", "flag", "pubkey", "error", err)
-	}
-
-	if err := createCmd.MarkFlagRequired("allowed"); err != nil {
-		Log.Errorw("Failed to mark flag as required", "flag", "allowed", "error", err)
 	}
 
 	if err := createCmd.MarkFlagRequired("keepalive"); err != nil {
@@ -134,18 +144,4 @@ func init() {
 	}
 
 	rootCmd.AddCommand(createCmd)
-}
-
-func pickPrimaryIP(cidrs []string) net.IP {
-	for _, c := range cidrs {
-		ip, ipNet, err := net.ParseCIDR(c)
-		if err != nil {
-			continue
-		}
-		ones, bits := ipNet.Mask.Size()
-		if (ip.To4() != nil && ones == 32 && bits == 32) || (ip.To4() == nil && ones == 128 && bits == 128) {
-			return ip
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
## Description
This PR adds automatic IP pool allocation support to `gophergate-wg-agent`.

The agent can now load an IPv4 allocation range from environment variables, find the next available IP address, assign it to a newly create WireGuard peer, and persist the allocation in PostgreSQL.

The allocation process is handled by the agent rather than the frontend. This ensures that the selected IP address is checked against existing peer records and allocated transactionally, reducing the risk of duplicate assignments during concurrent peer creation requests.

## Related Issue(s) and PR(s)
- Related to #171 

## Changes Made
- Added configurable IPv4 pool support using:
  - `WG_IP_POOL_CIDR`
  - `WG_IP_POOL_START`
  - `WG_IP_POOL_END`
  - `WG_IP_POOL_RESERVED`
- Added IP pool parsing and validation.
- Added automatic selection of the lowest available IP address.
- Added support for reserved IP addresses that must not be allocated.
- Added PostgreSQL transaction-based IP allocation.
- Added a PostgreSQL advisory lock to prevent concurrent requests from selecting the same IP.
- Added database queries for retrieving allocated IP addresses within the configured range.
- Added `GetIPPool` v2 gRPC handler.
- Added IP pool capacity, allocated count, available count, reserved addresses, and next available IP information.
- Added `auto_assign_ip` handling to the v2 peer creation flow.
- Added `assigned_ip` and `assigned_cidr` to peer creation responses.
- Added stored peer IP addresses to peer list, peer detail, dashboard, and peer directory responses.
- Completed the existing v2 `GetPeerPage` handler.
- Updated peer creation to persist the final `allowed_ips` values.
- Automatically appends the assigned peer `/32` address to WireGuard `AllowedIPs`.
- Preserves additional routed CIDRs supplied during automatic peer creation.
- Added cleanup handling when the database allocation succeeds but WireGuard configuration fails.
- Added rollback handling when manual WireGuard configuration succeeds but database insertion fails.
- Added CLI support through the `--auto-ip` flag.
- Added unit tests for IP pool parsing, validation, reserved addresses, default ranges, and pool exhaustion.

## Additional Notes
Automatic IP assignment requires PostgreSQL because the database is used as the source of truth for allocated peer addresses.

Example configuration for `.env`:
```dotenv
WG_IP_POOL_CIDR=10.13.13.0/24
WG_IP_POOL_START=10.13.13.10
WG_IP_POOL_END=10.13.13.250
WG_IP_POOL_RESERVED=10.13.13.20,10.13.13.21
```
The WireGuard server IP must not be included in the allocatable range. It should either be below the configured starting address or explicitly included in `WG_IP_POOL_RESERVED`.

The `next_available_ip` returned by `GetIPPool` is only a preview. The frontend should submit `auto_assign_ip: true` and use the `assigned_ip` returned by `CreatePeer`, because the final address is selected and committed during the creation transaction.

Testing commands:
```bash
go mod tidy
gofmt -w internal pkg
go test ./...
```